### PR TITLE
Make LLVM an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,15 @@ set(CMAKE_CXX_STANDARD 23)
 
 include(cmake/compile_options.cmake)
 
-find_package(LLVM CONFIG REQUIRED
-  COMPONENTS
-    LLVMDebugInfoPDB
-    LLVMDebugInfoDWARF
-)
+option(SNAIL_WITH_LLVM "Required to resolve symbols from PDB and DWARF files." ON)
+
+if(SNAIL_WITH_LLVM)
+  find_package(LLVM CONFIG REQUIRED
+    COMPONENTS
+      LLVMDebugInfoPDB
+      LLVMDebugInfoDWARF
+  )
+endif()
 
 find_package(nlohmann_json CONFIG REQUIRED)
 

--- a/snail/analysis/CMakeLists.txt
+++ b/snail/analysis/CMakeLists.txt
@@ -24,12 +24,21 @@ target_link_libraries(analysis
 
     etl 
     perf_data
-
-    LLVMDebugInfoPDB
-    LLVMDebugInfoDWARF
   PUBLIC
     common
 )
+
+if(SNAIL_WITH_LLVM)
+  target_link_libraries(analysis
+    PRIVATE
+      LLVMDebugInfoPDB
+      LLVMDebugInfoDWARF
+  )
+  target_compile_definitions(analysis
+    PUBLIC
+      SNAIL_HAS_LLVM
+  )
+endif()
 
 target_include_directories(analysis SYSTEM PRIVATE
   ${LLVM_INCLUDE_DIRS}

--- a/snail/analysis/detail/dwarf_resolver.hpp
+++ b/snail/analysis/detail/dwarf_resolver.hpp
@@ -62,11 +62,13 @@ private:
         std::hash<instruction_pointer_t>  address_hasher;
     };
 
+#ifdef SNAIL_HAS_LLVM
     struct context_storage;
 
     context_storage* get_dwarf_context(const module_info& module);
 
     std::unordered_map<module_key, std::unique_ptr<context_storage>, module_key_hasher> dwarf_context_cache;
+#endif // SNAIL_HAS_LLVM
 
     std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache;
 };

--- a/snail/analysis/detail/pdb_resolver.hpp
+++ b/snail/analysis/detail/pdb_resolver.hpp
@@ -6,11 +6,15 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef SNAIL_HAS_LLVM
+
 namespace llvm::pdb {
 
 class IPDBSession;
 
 } // namespace llvm::pdb
+
+#endif // SNAIL_HAS_LLVM
 
 namespace snail::analysis::detail {
 
@@ -68,9 +72,11 @@ private:
         std::hash<instruction_pointer_t> address_hasher;
     };
 
+#ifdef SNAIL_HAS_LLVM
     llvm::pdb::IPDBSession* get_pdb_session(const module_info& module);
 
     std::unordered_map<module_key, std::unique_ptr<llvm::pdb::IPDBSession>, module_key_hasher> pdb_session_cache;
+#endif // SNAIL_HAS_LLVM
 
     std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache;
 };


### PR DESCRIPTION
Without LLVM the symbol resolution does not work and we always create "generic" symbols.

While this makes the tool mostly useless, it simplifies compilation a lot for quick testing scenarios.