### PR TITLE
Use static libraries for Windows CI dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         include:
           - os: windows-latest
-            triplet: x64-windows-release
+            triplet: x64-windows-static-release
             arch: x86_64
             platform: windows
           - os: ubuntu-latest
@@ -48,13 +48,13 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v10
         with:
-          vcpkgGitCommitId: 'f14984af3738e69f197bf0e647a8dca12de92996'
+          vcpkgGitCommitId: 'a325228200d7f229f3337e612e0077f2a5307090'
         
       - name: Build & Test project
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-vcpkg'
-          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}']"
+          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
 
           buildPreset: 'ninja-vcpkg'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
 
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      VCPKG_GIT_COMMIT_ID: 'a325228200d7f229f3337e612e0077f2a5307090'
 
     steps:
       - name: Install gcc-13
@@ -45,11 +46,19 @@ jobs:
           cmakeVersion: "~3.25.0"
           ninjaVersion: "^1.11.1"
           
-      - name: Setup vcpkg
+      - name: Setup vcpkg (windows)
+        if: runner.os == 'Windows'
         uses: lukka/run-vcpkg@v10
         with:
-          vcpkgGitCommitId: 'a325228200d7f229f3337e612e0077f2a5307090'
-        
+          vcpkgDirectory: 'C:\vcpkg'
+          vcpkgGitCommitId: '${{ env.VCPKG_GIT_COMMIT_ID }}'
+
+      - name: Setup vcpkg (non-windows)
+        if: runner.os != 'Windows'
+        uses: lukka/run-vcpkg@v10
+        with:
+          vcpkgGitCommitId: '${{ env.VCPKG_GIT_COMMIT_ID }}'
+
       - name: Build & Test project
         uses: lukka/run-cmake@v10
         with:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(test_etl
     etl/event_observer.cpp
 )
 target_link_libraries(test_etl compile_options etl)
-target_link_libraries(test_etl third_party::gtest third_party::gtest_main)
+target_link_libraries(test_etl GTest::gtest GTest::gtest_main)
 gtest_discover_tests(test_etl)
 
 
@@ -15,14 +15,14 @@ add_executable(test_perf_data
     perf_data/event_observer.cpp
 )
 target_link_libraries(test_perf_data compile_options perf_data)
-target_link_libraries(test_perf_data third_party::gtest third_party::gtest_main)
+target_link_libraries(test_perf_data GTest::gtest GTest::gtest_main)
 gtest_discover_tests(test_perf_data)
 
 add_executable(test_analysis
     analysis/module_map.cpp
 )
 target_link_libraries(test_analysis compile_options analysis)
-target_link_libraries(test_analysis third_party::gtest third_party::gtest_main)
+target_link_libraries(test_analysis GTest::gtest GTest::gtest_main)
 gtest_discover_tests(test_analysis)
 
 add_executable(test_jsonrpc
@@ -35,5 +35,5 @@ if(UNIX)
     target_sources(test_jsonrpc PRIVATE jsonrpc/unix_domain_socket.cpp)
 endif()
 target_link_libraries(test_jsonrpc compile_options jsonrpc)
-target_link_libraries(test_jsonrpc third_party::gtest third_party::gtest_main)
+target_link_libraries(test_jsonrpc GTest::gtest GTest::gtest_main)
 gtest_discover_tests(test_jsonrpc)

--- a/third-party/gtest/CMakeLists.txt
+++ b/third-party/gtest/CMakeLists.txt
@@ -1,107 +1,12 @@
 
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.14.0)
 
-option(USE_SYSTEM_GOOGLETEST "Use system googletest and do not download/build an own version of it" OFF)
+include(FetchContent)
 
-if(USE_SYSTEM_GOOGLETEST)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        b796f7d44681514f58a683a3a71ff17c94edb0c1 # v1.13.0
+)
 
-  find_package(GTest REQUIRED)
-
-  set_target_properties(GTest::GTest PROPERTIES
-    IMPORTED_GLOBAL TRUE
-  )
-  set_target_properties(GTest::Main PROPERTIES
-    IMPORTED_GLOBAL TRUE
-  )
-
-  add_library(third_party::gtest INTERFACE IMPORTED GLOBAL)
-  add_library(third_party::gtest_main INTERFACE IMPORTED GLOBAL)
-
-  set_target_properties(third_party::gtest PROPERTIES
-    INTERFACE_LINK_LIBRARIES GTest::GTest
-  )
-  set_target_properties(third_party::gtest_main PROPERTIES
-    INTERFACE_LINK_LIBRARIES GTest::Main
-  )
-else()
-  project(3rd-party-googletest NONE)
-
-  if(UNIX AND NOT APPLE)
-    find_package(Threads REQUIRED)
-  endif()
-
-  include(ExternalProject)
-
-  set(GTEST_FORCE_SHARED_CRT ON)
-  set(GTEST_DISABLE_PTHREADS OFF)
-
-  if(MINGW)
-    set(GTEST_DISABLE_PTHREADS ON)
-  endif()
-
-  if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Release)
-  endif()
-
-  # set(GTEST_INTERFACE_COMPILE_DEFINITIONS "GTEST_LANG_CXX11")
-
-  # set(ADDITIONAL_ARGS)
-  # if(WIN32)
-  #   list(APPEND ADDITIONAL_ARGS PATCH_COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/internal_utils.cmake.patched" <SOURCE_DIR>/googletest/cmake/internal_utils.cmake)
-  #   list(APPEND GTEST_INTERFACE_COMPILE_DEFINITIONS "_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING")
-  # endif()
-
-  ExternalProject_Add(gtest-external
-    URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz
-    TIMEOUT 60
-    CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=Debug
-      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=Release
-      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO:PATH=RelWithDebInfo
-      -Dgtest_force_shared_crt=${GTEST_FORCE_SHARED_CRT}
-      -Dgtest_disable_pthreads=${GTEST_DISABLE_PTHREADS}
-      -DBUILD_GTEST=ON
-    INSTALL_COMMAND ""
-    LOG_DOWNLOAD ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    BUILD_BYPRODUCTS
-      "gtest-external-prefix/src/gtest-external-build/googletest/${CMAKE_BUILD_TYPE}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      "gtest-external-prefix/src/gtest-external-build/googletest/${CMAKE_BUILD_TYPE}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-    ${ADDITIONAL_ARGS}
-  )
-
-  set_target_properties(gtest-external PROPERTIES FOLDER 3rd_party)
-
-  ExternalProject_Get_Property(gtest-external source_dir)
-  set(GTEST_INCLUDE_DIRS "${source_dir}/googletest/include")
-
-  ExternalProject_Get_Property(gtest-external binary_dir)
-  set(GTEST_LIBRARY_DIR "${binary_dir}/googletest")
-
-  file(MAKE_DIRECTORY ${GTEST_INCLUDE_DIRS})
-
-  add_library(third_party::gtest IMPORTED STATIC GLOBAL)
-  add_dependencies(third_party::gtest gtest-external)
-  set_target_properties(third_party::gtest PROPERTIES
-      IMPORTED_LOCATION "${GTEST_LIBRARY_DIR}/${CMAKE_BUILD_TYPE}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_DEBUG "${GTEST_LIBRARY_DIR}/Debug/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_RELEASE "${GTEST_LIBRARY_DIR}/Release/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_RELWITHDEBINFO "${GTEST_LIBRARY_DIR}/RelWithDebInfo/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}"
-      INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}"
-      INTERFACE_COMPILE_DEFINITIONS "${GTEST_INTERFACE_COMPILE_DEFINITIONS}"
-  )
-
-  add_library(third_party::gtest_main IMPORTED STATIC GLOBAL)
-  add_dependencies(third_party::gtest_main gtest-external)
-  set_target_properties(third_party::gtest_main PROPERTIES
-      IMPORTED_LOCATION "${GTEST_LIBRARY_DIR}/${CMAKE_BUILD_TYPE}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_DEBUG "${GTEST_LIBRARY_DIR}/Debug/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_RELEASE "${GTEST_LIBRARY_DIR}/Release/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LOCATION_RELWITHDEBINFO "${GTEST_LIBRARY_DIR}/RelWithDebInfo/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}"
-      INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIRS}"
-  )
-endif()
+FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
This should make the resulting executable self-contained.