### PR TITLE
Support *.diagsession files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ endif()
 
 find_package(nlohmann_json CONFIG REQUIRED)
 
+find_package(libzippp CONFIG REQUIRED)
+
 # =======
 # LIBRARIES
 

--- a/snail/analysis/CMakeLists.txt
+++ b/snail/analysis/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(analysis
 
     data_provider.cpp
     etl_data_provider.cpp
+    diagsession_data_provider.cpp
     perf_data_data_provider.cpp
     
     analysis.cpp
@@ -24,6 +25,8 @@ target_link_libraries(analysis
 
     etl 
     perf_data
+    
+    libzippp::libzippp
   PUBLIC
     common
 )

--- a/snail/analysis/data_provider.cpp
+++ b/snail/analysis/data_provider.cpp
@@ -3,6 +3,7 @@
 
 #include <format>
 
+#include <snail/analysis/diagsession_data_provider.hpp>
 #include <snail/analysis/etl_data_provider.hpp>
 #include <snail/analysis/perf_data_data_provider.hpp>
 
@@ -21,6 +22,10 @@ std::unique_ptr<data_provider> snail::analysis::make_data_provider(const std::fi
     if(extension == ".etl")
     {
         return std::make_unique<snail::analysis::etl_data_provider>();
+    }
+    else if(extension == ".diagsession")
+    {
+        return std::make_unique<snail::analysis::diagsession_data_provider>();
     }
     else if(extension == ".data")
     {

--- a/snail/analysis/diagsession_data_provider.cpp
+++ b/snail/analysis/diagsession_data_provider.cpp
@@ -1,0 +1,131 @@
+
+#include <snail/analysis/diagsession_data_provider.hpp>
+
+#include <filesystem>
+#include <format>
+#include <fstream>
+#include <stdexcept>
+
+#include <libzippp.h>
+
+#include <snail/common/filename.hpp>
+#include <snail/common/trim.hpp>
+
+using namespace snail;
+using namespace snail::analysis;
+
+namespace {
+
+std::optional<std::string_view> extract_xml_attribute(std::string_view xml_node, std::string_view attribute_name)
+{
+    const auto attr_name_offset = xml_node.find(attribute_name);
+    if(attr_name_offset == std::string_view::npos) return {};
+    if(attr_name_offset + attribute_name.size() + 3 >= xml_node.size()) return {}; // we need at least '<node_name>=""'
+    if(xml_node.substr(attr_name_offset + attribute_name.size(), 2) != "=\"") return {};
+
+    const auto attr_value_offset = attr_name_offset + attribute_name.size() + 2;
+
+    const auto attr_value_end = xml_node.find("\"", attr_value_offset);
+    if(attr_value_end == std::string_view::npos) return {};
+
+    return xml_node.substr(attr_value_offset, attr_value_end - attr_value_offset);
+}
+
+} // namespace
+
+diagsession_data_provider::~diagsession_data_provider()
+{
+    try_cleanup();
+}
+
+void diagsession_data_provider::process(const std::filesystem::path& file_path)
+{
+    libzippp::ZipArchive archive(file_path.string());
+    if(!archive.open(libzippp::ZipArchive::ReadOnly))
+    {
+        throw std::runtime_error(std::format("Could not open diagsession file '{}'", file_path.string()));
+    }
+
+    // Extract the ETL file path from the metadata within the diagsession file.
+    std::optional<std::string> archive_etl_file_path;
+    {
+        const auto metadataEntry = archive.getEntry("metadata.xml");
+        if(metadataEntry.isNull())
+        {
+            throw std::runtime_error(std::format("Could not find metadata.xml in '{}'", file_path.string()));
+        }
+
+        std::stringstream metadata_stream;
+        metadataEntry.readContent(metadata_stream);
+
+        // NOTE: We want to spare ourselves from a dependency to a real XML parser library and hence
+        //       we try to extract only the necessary information "by hand".
+        //       This assumes that the XML file "behaves well enough". Hopefully that assumption is reasonable
+        //       since currently we only deal with diagsession and files written by VCDiagnostics.exe.
+        std::string line;
+        while(std::getline(metadata_stream, line))
+        {
+            const auto trimmed = common::trim(line);
+
+            // Try to find the line that includes the `<Resource />` XML Node.
+            // IMPLICIT ASSUMPTION 1: We ignore the path of the XML Node, and assume that it is 'Package.Content.Resource'.
+            // IMPLICIT ASSUMPTION 2: The whole node is actually within a single line.
+            if(!trimmed.starts_with("<Resource ") || !trimmed.ends_with("/>")) continue;
+            if(!trimmed.contains("Type=\"DiagnosticsHub.Resource.EtlFile\"")) continue;
+
+            // Try to extract the name and prefix attributes
+            const auto etl_file_name   = extract_xml_attribute(trimmed, "Name");
+            const auto etl_file_prefix = extract_xml_attribute(trimmed, "ResourcePackageUriPrefix");
+
+            if(!etl_file_name) continue;
+            if(!etl_file_prefix) continue;
+
+            archive_etl_file_path = std::format("{}/{}", *etl_file_prefix, *etl_file_name);
+
+            break;
+        }
+    }
+
+    if(!archive_etl_file_path)
+    {
+        throw std::runtime_error(std::format("Could not extract ETL file path from metadata in '{}'", file_path.string()));
+    }
+
+    // Extract the ETL file to a temporary directory
+    const auto temp_dir = std::filesystem::temp_directory_path() / "snail" / common::make_random_filename(20);
+    std::filesystem::create_directories(temp_dir);
+
+    // Clean-up any previously created temporary files.
+    try_cleanup();
+
+    temp_etl_file_path_ = temp_dir / std::filesystem::path(*archive_etl_file_path).filename();
+
+    {
+        const auto etlFileEntry = archive.getEntry(*archive_etl_file_path);
+        if(etlFileEntry.isNull())
+        {
+            throw std::runtime_error(std::format("Could not find ETL file '{}' in '{}'", *archive_etl_file_path, file_path.string()));
+        }
+
+        std::ofstream etl_file_stream(*temp_etl_file_path_, std::ios::binary);
+        etlFileEntry.readContent(etl_file_stream);
+    }
+
+    etl_data_provider::process(*temp_etl_file_path_);
+}
+
+void diagsession_data_provider::try_cleanup() noexcept
+{
+    if(!temp_etl_file_path_) return;
+
+    std::error_code error_code;
+    std::filesystem::remove_all(temp_etl_file_path_->parent_path(), error_code);
+    if(!error_code)
+    {
+        temp_etl_file_path_ = std::nullopt;
+    }
+    // NOTE: we simply ignore the case when there was an error:
+    //   1. There is nothing we can do about it anyways?!
+    //   2. This needs to be callable from a destructor, hence it should not throw.
+    //   3. The directory we failed to delete is located in an official temporary directory. The OS can still clean it up.
+}

--- a/snail/analysis/diagsession_data_provider.hpp
+++ b/snail/analysis/diagsession_data_provider.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <snail/analysis/etl_data_provider.hpp>
+
+namespace snail::analysis {
+
+// The diagsession data provider is basically just an ETL data provider
+// that first extracts the ETL file that is contained within a diagsession file.
+class diagsession_data_provider : public etl_data_provider
+{
+public:
+    virtual ~diagsession_data_provider();
+
+    virtual void process(const std::filesystem::path& file_path) override;
+
+private:
+    std::optional<std::filesystem::path> temp_etl_file_path_;
+
+    void try_cleanup() noexcept;
+};
+
+} // namespace snail::analysis

--- a/snail/common/CMakeLists.txt
+++ b/snail/common/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(common)
 target_sources(common
   PRIVATE
     unicode.cpp
+    trim.cpp
 )
 
 target_link_libraries(common 

--- a/snail/common/CMakeLists.txt
+++ b/snail/common/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(common
   PRIVATE
     unicode.cpp
     trim.cpp
+    filename.cpp
 )
 
 target_link_libraries(common 

--- a/snail/common/filename.cpp
+++ b/snail/common/filename.cpp
@@ -1,0 +1,26 @@
+
+#include <snail/common/filename.hpp>
+
+#include <random>
+
+using namespace snail::common;
+
+std::string snail::common::make_random_filename(std::size_t length)
+{
+    static constexpr const char characters[]   = "0123456789abcdefghijklmnopqrstuvwxyz";
+    static constexpr auto       num_characters = sizeof(characters) - 1; // -1 for null-termination
+
+    std::random_device rd;
+    std::mt19937       generator(rd());
+
+    std::uniform_int_distribution<std::size_t> distribution(0, num_characters - 1); // -1 because std::uniform_int_distribution creates numbers in a closed interval.
+
+    std::string result;
+    result.reserve(length);
+    for(std::size_t i = 0; i < length; ++i)
+    {
+        result.push_back(characters[distribution(generator)]);
+    }
+
+    return result;
+}

--- a/snail/common/filename.hpp
+++ b/snail/common/filename.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace snail::common {
+
+std::string make_random_filename(std::size_t length);
+
+} // namespace snail::common

--- a/snail/common/trim.cpp
+++ b/snail/common/trim.cpp
@@ -1,0 +1,32 @@
+
+#include <snail/common/trim.hpp>
+
+#include <cctype>
+
+#include <algorithm>
+#include <ranges>
+
+using namespace snail::common;
+
+std::string_view snail::common::trim_left(std::string_view input)
+{
+    const auto first_nospace_iter = std::ranges::find_if(input,
+                                                         [](int c)
+                                                         { return !std::isspace(c); });
+    input.remove_prefix(std::distance(input.cbegin(), first_nospace_iter));
+    return input;
+}
+
+std::string_view snail::common::trim_right(std::string_view input)
+{
+    const auto first_reversed_nospace_iter = std::ranges::find_if(input | std::views::reverse,
+                                                                  [](int c)
+                                                                  { return !std::isspace(c); });
+    input.remove_suffix(std::distance(input.crbegin(), first_reversed_nospace_iter));
+    return input;
+}
+
+std::string_view snail::common::trim(std::string_view input)
+{
+    return trim_left(trim_right(input));
+}

--- a/snail/common/trim.hpp
+++ b/snail/common/trim.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string_view>
+
+namespace snail::common {
+
+std::string_view trim_left(std::string_view input);
+
+std::string_view trim_right(std::string_view input);
+
+std::string_view trim(std::string_view input);
+
+} // namespace snail::common

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 
 include(GoogleTest)
 
+add_executable(test_common
+    common/utility.cpp
+)
+target_link_libraries(test_common compile_options common)
+target_link_libraries(test_common GTest::gtest GTest::gtest_main)
+gtest_discover_tests(test_common)
+
 add_executable(test_etl
     etl/parser.cpp
     etl/event_observer.cpp

--- a/tests/common/utility.cpp
+++ b/tests/common/utility.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <snail/common/filename.hpp>
+#include <snail/common/trim.hpp>
+
+using namespace snail::common;
+
+using namespace std::string_view_literals;
+
+TEST(Trim, Left)
+{
+    EXPECT_EQ(trim_left("a b\tc\nd   "), "a b\tc\nd   "sv);
+    EXPECT_EQ(trim_left("   a b\tc\nd   "), "a b\tc\nd   "sv);
+    EXPECT_EQ(trim_left("  \n\t a b\tc\nd   "), "a b\tc\nd   "sv);
+}
+
+TEST(Trim, Right)
+{
+    EXPECT_EQ(trim_right("   a b\tc\nd"), "   a b\tc\nd"sv);
+    EXPECT_EQ(trim_right("   a b\tc\nd   "), "   a b\tc\nd"sv);
+    EXPECT_EQ(trim_right("   a b\tc\nd \n\t    "), "   a b\tc\nd"sv);
+}
+
+TEST(Trim, Both)
+{
+    EXPECT_EQ(trim("   a b\tc\nd"), "a b\tc\nd"sv);
+    EXPECT_EQ(trim("   a b\tc\nd   "), "a b\tc\nd"sv);
+    EXPECT_EQ(trim("   a b\tc\nd \n\t    "), "a b\tc\nd"sv);
+    EXPECT_EQ(trim("a b\tc\nd   "), "a b\tc\nd"sv);
+    EXPECT_EQ(trim("   a b\tc\nd   "), "a b\tc\nd"sv);
+    EXPECT_EQ(trim("  \n\t a b\tc\nd   "), "a b\tc\nd"sv);
+}

--- a/tests/common/utility.cpp
+++ b/tests/common/utility.cpp
@@ -30,3 +30,20 @@ TEST(Trim, Both)
     EXPECT_EQ(trim("   a b\tc\nd   "), "a b\tc\nd"sv);
     EXPECT_EQ(trim("  \n\t a b\tc\nd   "), "a b\tc\nd"sv);
 }
+
+TEST(RandomFilename, Create)
+{
+    const char allowed_characters[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+    const std::size_t desired_length = 20;
+
+    const auto name = make_random_filename(desired_length);
+    EXPECT_EQ(name.size(), desired_length);
+    EXPECT_EQ(name.find_first_not_of(allowed_characters), std::string_view::npos) << "name: " << name;
+}
+
+TEST(RandomFilename, Empty)
+{
+    const auto name = make_random_filename(0);
+    EXPECT_EQ(name.size(), 0);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,8 @@
         "llvm"
     ],
     "dependencies": [
-        "nlohmann-json"
+        "nlohmann-json",
+        "libzippp"
     ],
     "features": {
         "llvm": {


### PR DESCRIPTION
These files are basically just ZIP files that include a `metadata.xml` and at least an additional ETL files. We extract the ZIP file by adding a new dependency to [libzippp](https://github.com/ctabin/libzippp).

The XML file is parsed manually to only extract the path to the ETL file. This could potentially lead to problems when the XML file changes in the future and the limited parsing routines implemented in this MR are not sufficient anymore. On the other hand we do not need to add another dependency to an XML parsing library yet.