### PR TITLE
Fix compiler warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: 'ninja-vcpkg'
-          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded']"
+          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded', '-DCMAKE_COMPILE_WARNING_AS_ERROR=ON']"
 
           buildPreset: 'ninja-vcpkg'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           cmake --install ${{ github.workspace }}/build/ninja-vcpkg --component server --prefix ${{ github.workspace }}/install
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with: 
           name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}
           path: ${{ github.workspace }}/install/bin/snail-server*

--- a/cmake/compile_options.cmake
+++ b/cmake/compile_options.cmake
@@ -15,6 +15,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_FRONTEND_VARIA
     "-Wall"
     "-Wextra"
     "-pedantic"
+    "-Wno-missing-field-initializers" # Missing initializers are value initialized, which is exactly what we want
   )
 endif()
 

--- a/cmake/compile_options.cmake
+++ b/cmake/compile_options.cmake
@@ -1,8 +1,6 @@
 
 add_library(compile_options INTERFACE)
 
-option(SNAIL_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
-
 if(MSVC)
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -12,22 +10,12 @@ if(MSVC)
     "/W4"
     "/permissive-"
   )
-  if(SNAIL_WARNINGS_AS_ERRORS)
-    target_compile_options(compile_options INTERFACE
-        "/WX"
-    )
-  endif()
 elseif(CMAKE_COMPILER_IS_GNUCC)
   target_compile_options(compile_options INTERFACE
     "-Wall"
     "-Wextra"
     "-pedantic"
   )
-  if(SNAIL_WARNINGS_AS_ERRORS)
-    target_compile_options(compile_options INTERFACE
-        "-Werror"
-    )
-  endif()
 endif()
 
 target_compile_features(compile_options INTERFACE cxx_std_23)

--- a/cmake/compile_options.cmake
+++ b/cmake/compile_options.cmake
@@ -1,7 +1,7 @@
 
 add_library(compile_options INTERFACE)
 
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   endif()
@@ -10,7 +10,7 @@ if(MSVC)
     "/W4"
     "/permissive-"
   )
-elseif(CMAKE_COMPILER_IS_GNUCC)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")
   target_compile_options(compile_options INTERFACE
     "-Wall"
     "-Wextra"

--- a/snail/analysis/detail/module_map.cpp
+++ b/snail/analysis/detail/module_map.cpp
@@ -80,7 +80,7 @@ void module_map::insert(module_info module, common::timestamp_t load_timestamp)
 
     // Check whether we need to enlarge the total address range at the beginning
     // and prepend a new range part if necessary.
-    bool inserted_before = false;
+    [[maybe_unused]] bool inserted_before = false;
     if(address_ranges.front().begin_address > to_insert_begin)
     {
         const auto current_total_begin = address_ranges.front().begin_address;
@@ -100,7 +100,7 @@ void module_map::insert(module_info module, common::timestamp_t load_timestamp)
 
     // Check whether we need to enlarge the total address range at the end
     // and append a new range part if necessary.
-    bool inserted_after = false;
+    [[maybe_unused]] bool inserted_after = false;
     if(address_ranges.back().end_address < to_insert_end)
     {
         const auto current_total_end = address_ranges.back().end_address;
@@ -158,7 +158,7 @@ void module_map::insert(module_info module, common::timestamp_t load_timestamp)
        modules[first_overlapping_range->active_modules.back().module_index].page_offset == modules.back().page_offset)
     {
         assert(!inserted_before && !inserted_after);
-        const auto& last_active_module = modules[first_overlapping_range->active_modules.back().module_index];
+        [[maybe_unused]] const auto& last_active_module = modules[first_overlapping_range->active_modules.back().module_index];
         assert(last_active_module.base == modules.back().base);
         assert(last_active_module.size == modules.back().size);
         modules.pop_back();

--- a/snail/analysis/detail/perf_data_file_process_context.cpp
+++ b/snail/analysis/detail/perf_data_file_process_context.cpp
@@ -55,14 +55,6 @@ void perf_data_file_process_context::finish()
             }
         }
     }
-
-    for(const auto& [process_id, storage] : samples_per_process)
-    {
-        const auto* const process = processes.find_at(process_id, storage.first_sample_time);
-        assert(process != nullptr); // FIXME: handle this case
-
-        process->payload.name;
-    }
 }
 
 template<typename T>

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -252,9 +252,9 @@ common::generator<const sample_data&> etl_data_provider::samples(common::process
     {
         if(sample.user_mode_stack)
         {
-            const auto& user_stack       = process_context.stack(*sample.user_mode_stack);
-            const auto  starts_in_kernel = is_kernel_address(user_stack.back(), pointer_size);
-            const auto  ends_in_kernel   = is_kernel_address(user_stack.front(), pointer_size);
+            const auto&                 user_stack       = process_context.stack(*sample.user_mode_stack);
+            [[maybe_unused]] const auto starts_in_kernel = is_kernel_address(user_stack.back(), pointer_size);
+            const auto                  ends_in_kernel   = is_kernel_address(user_stack.front(), pointer_size);
             assert(!starts_in_kernel);
 
             if(ends_in_kernel)

--- a/snail/etl/etl_file.cpp
+++ b/snail/etl/etl_file.cpp
@@ -191,7 +191,7 @@ std::size_t process_event_header_trace(std::span<const std::byte>   payload_buff
 {
     const auto trace_header = parser::event_header_trace_header_view(payload_buffer);
 
-    const auto is_extended = (trace_header.flags() & static_cast<std::underlying_type_t<parser::event_header_flag>>(parser::event_header_flag::extended_info)) != 0;
+    [[maybe_unused]] const auto is_extended = (trace_header.flags() & static_cast<std::underlying_type_t<parser::event_header_flag>>(parser::event_header_flag::extended_info)) != 0;
 
     assert(!is_extended); // not yet supported
 
@@ -295,7 +295,7 @@ void etl_file::open(const std::filesystem::path& file_path)
         return; // TODO: handle error
     }
 
-    const auto marker = parser::generic_trace_marker_view(file_buffer.subspan(parser::wmi_buffer_header_view::static_size));
+    [[maybe_unused]] const auto marker = parser::generic_trace_marker_view(file_buffer.subspan(parser::wmi_buffer_header_view::static_size));
     assert(marker.is_trace_header() && marker.is_trace_header_event_trace() && !marker.is_trace_message());
     assert(marker.header_type() == parser::trace_header_type::system32 ||
            marker.header_type() == parser::trace_header_type::system64);

--- a/snail/etl/etl_file.cpp
+++ b/snail/etl/etl_file.cpp
@@ -69,7 +69,7 @@ buffer_info read_buffer(std::ifstream&                          file_stream,
     file_stream.read(reinterpret_cast<char*>(buffer_data.data()), buffer_data.size());
 
     const auto read_bytes = file_stream.tellg() - buffer_start_pos;
-    if(read_bytes < parser::wmi_buffer_header_view::static_size)
+    if(read_bytes < static_cast<std::streamoff>(parser::wmi_buffer_header_view::static_size))
     {
         std::cout << std::format(
                          "ERROR: Invalid ETL file: insufficient size for buffer header. Expected {} but read only {}.",
@@ -277,7 +277,7 @@ void etl_file::open(const std::filesystem::path& file_path)
     file_stream_.read(reinterpret_cast<char*>(file_buffer_data.data()), file_buffer_data.size());
 
     const auto read_bytes = file_stream_.tellg() - std::streampos(0);
-    if(read_bytes < parser::wmi_buffer_header_view::static_size)
+    if(read_bytes < static_cast<std::streamoff>(parser::wmi_buffer_header_view::static_size))
     {
         std::cout << "ERROR: Invalid ETL file: insufficient size for buffer header" << std::endl;
         return; // TODO: handle error
@@ -347,7 +347,7 @@ void etl_file::process(event_observer& callbacks)
             assert(file_stream_.good());
 
             const auto read_bytes = file_stream_.tellg() - init_position;
-            if(read_bytes < parser::wmi_buffer_header_view::static_size)
+            if(read_bytes < static_cast<std::streamoff>(parser::wmi_buffer_header_view::static_size))
             {
                 std::cout << std::format(
                                  "ERROR: Invalid ETL file: insufficient size for buffer header (index {}). Expected {} but read only {}.",

--- a/snail/jsonrpc/detail/request.hpp
+++ b/snail/jsonrpc/detail/request.hpp
@@ -34,7 +34,7 @@ template<std::size_t I>
 using size_c = std::integral_constant<std::size_t, I>;
 
 template<typename F, typename... Ts, std::size_t... Is>
-constexpr void for_each(const std::tuple<Ts...>& data, F func, std::index_sequence<Is...>)
+constexpr void for_each(const std::tuple<Ts...>& data, [[maybe_unused]] F func, std::index_sequence<Is...>)
 {
     (func(size_c<Is>(), std::get<Is>(data)), ...);
 }

--- a/snail/jsonrpc/jsonrpc_v2_protocol.cpp
+++ b/snail/jsonrpc/jsonrpc_v2_protocol.cpp
@@ -49,7 +49,7 @@ request v2_protocol::load_request(std::string_view content)
         id->swap(*id_data);
     }
 
-    const auto expected_count = id == data.end() ? 3 : 4; // jsonrpc, method, params and optionally id
+    const auto expected_count = id == data.end() ? std::size_t(3) : std::size_t(4); // jsonrpc, method, params and optionally id
     if(data.size() != expected_count) throw invalid_request_error("to many fields found.");
 
     return request{

--- a/snail/jsonrpc/server.hpp
+++ b/snail/jsonrpc/server.hpp
@@ -65,7 +65,7 @@ void server::register_request(HandlerType&& handler)
         [handler = std::forward<HandlerType>(handler)](const nlohmann::json& data) -> std::optional<nlohmann::json>
         {
             nlohmann::json response = std::invoke(handler, detail::unpack_request<RequestType>(data));
-            return std::move(response);
+            return response;
         });
 }
 

--- a/snail/perf_data/perf_data_file.cpp
+++ b/snail/perf_data/perf_data_file.cpp
@@ -65,7 +65,14 @@ std::string read_string(std::ifstream& file_stream, std::endian data_byte_order)
 
     std::vector<char> buffer;
     buffer.resize(length + 1);
-    buffer.back() = '\0'; // just to make sure we definitely do have a valid string termination
+#ifdef __GNUC__ // workaround for invalid GCC diagnostic
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+    buffer.back() = '\0'; // just to make sure we definitely have a valid string termination
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
 
     file_stream.read(buffer.data(), length);
 

--- a/snail/perf_data/perf_data_file.cpp
+++ b/snail/perf_data/perf_data_file.cpp
@@ -351,7 +351,7 @@ void perf_data_file::open(const std::filesystem::path& file_path)
 
     const auto read_bytes = file_stream_.tellg() - std::streampos(0);
 
-    if(read_bytes < parser::header_view::static_size)
+    if(read_bytes < static_cast<std::streamoff>(parser::header_view::static_size))
     {
         std::cout << std::format(
                          "ERROR: Invalid perf.data file: insufficient size for header. Expected {} but read only {}.",

--- a/snail/perf_data/perf_data_file.cpp
+++ b/snail/perf_data/perf_data_file.cpp
@@ -240,8 +240,8 @@ void read_metadata(std::ifstream&                            file_stream,
                 break;
             case parser::header_feature::event_desc:
             {
-                const auto nr_events = read_int<std::uint32_t>(file_stream, header.byte_order);
-                const auto attr_size = read_int<std::uint32_t>(file_stream, header.byte_order);
+                const auto                  nr_events = read_int<std::uint32_t>(file_stream, header.byte_order);
+                [[maybe_unused]] const auto attr_size = read_int<std::uint32_t>(file_stream, header.byte_order);
                 assert(attr_size == parser::event_attributes_view::static_size);
                 std::array<std::byte, parser::event_attributes_view::static_size> attribute_buffer;
                 for(std::uint32_t event_i = 0; event_i < nr_events; ++event_i)

--- a/snail/server/requests/requests.cpp
+++ b/snail/server/requests/requests.cpp
@@ -318,6 +318,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
     server.register_request<retrieve_functions_page_request>(
         [&](const retrieve_functions_page_request& request) -> nlohmann::json
         {
+            // TODO: Add `sort_by` and `sort_order` to request
             const auto sort_by    = function_data_type::self_samples;
             const auto sort_order = direction::descending;
 
@@ -329,20 +330,21 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
             const auto total_hits = storage.get_data({request.document_id()}).session_info().number_of_samples; // TODO: use filtered
 
             auto json_functions = nlohmann::json::array();
-            if(sort_order == direction::descending)
+            // if(sort_order == direction::descending)
+            assert(sort_order == direction::descending);
             {
                 for(const auto function_id : std::views::reverse(function_ids))
                 {
                     json_functions.push_back(make_function_json(stacks_analysis, stacks_analysis.get_function(function_id), total_hits));
                 }
             }
-            else
-            {
-                for(const auto function_id : function_ids)
-                {
-                    json_functions.push_back(make_function_json(stacks_analysis, stacks_analysis.get_function(function_id), total_hits));
-                }
-            }
+            // else
+            // {
+            //     for(const auto function_id : function_ids)
+            //     {
+            //         json_functions.push_back(make_function_json(stacks_analysis, stacks_analysis.get_function(function_id), total_hits));
+            //     }
+            // }
 
             return {
                 {"functions", json_functions}

--- a/tests/etl/event_observer.cpp
+++ b/tests/etl/event_observer.cpp
@@ -39,7 +39,7 @@ TEST(EtlDispatchEventObserver, Dispatch)
             EXPECT_EQ(header.timestamp, 3072009310573);
             EXPECT_EQ(header.type, 46);
 
-            EXPECT_EQ(event.instruction_pointer(), 18446735291273262474);
+            EXPECT_EQ(event.instruction_pointer(), 18446735291273262474ULL);
 
             common_perfinfo_called = true;
         });
@@ -57,7 +57,7 @@ TEST(EtlDispatchEventObserver, Dispatch)
                 EXPECT_EQ(full_header->packet().type(), 46);
             }
 
-            EXPECT_EQ(event.instruction_pointer(), 18446735291273262474);
+            EXPECT_EQ(event.instruction_pointer(), 18446735291273262474ULL);
 
             variant_perfinfo_called = true;
         });

--- a/tests/etl/parser.cpp
+++ b/tests/etl/parser.cpp
@@ -175,7 +175,7 @@ TEST(EtlParser, EventTraceV2HeaderEvent)
     EXPECT_EQ(event.version(), 83951626);
     EXPECT_EQ(event.provider_version(), 22621);
     EXPECT_EQ(event.number_of_processors(), 8);
-    EXPECT_EQ(event.end_time(), 133171255616974395);
+    EXPECT_EQ(event.end_time(), 133171255616974395ULL);
     EXPECT_EQ(event.timer_resolution(), 156250);
     EXPECT_EQ(event.max_file_size(), 0);
     EXPECT_EQ(event.log_file_mode(), 65537);
@@ -207,9 +207,9 @@ TEST(EtlParser, EventTraceV2HeaderEvent)
     EXPECT_EQ(event.time_zone_information().daylight_date().second(), 0);
     EXPECT_EQ(event.time_zone_information().daylight_date().milliseconds(), 0);
     EXPECT_EQ(event.time_zone_information().daylight_bias(), -60);
-    EXPECT_EQ(event.boot_time(), 133168183955000000);
+    EXPECT_EQ(event.boot_time(), 133168183955000000ULL);
     EXPECT_EQ(event.perf_freq(), 10000000);
-    EXPECT_EQ(event.start_time(), 133171255391510931);
+    EXPECT_EQ(event.start_time(), 133171255391510931ULL);
     EXPECT_EQ(event.reserved_flags(), 1);
     EXPECT_EQ(event.buffers_lost(), 0);
     EXPECT_EQ(event.session_name(), std::u16string(u"Relogger"));
@@ -223,7 +223,7 @@ TEST(EtlParser, PerfinfoV2SampledProfileEvent)
 
     const auto event = etl::parser::perfinfo_v2_sampled_profile_event_view(std::as_bytes(std::span(buffer)), 8);
 
-    EXPECT_EQ(event.instruction_pointer(), 18446735291273262474);
+    EXPECT_EQ(event.instruction_pointer(), 18446735291273262474ULL);
     EXPECT_EQ(event.thread_id(), 26400);
     EXPECT_EQ(event.count(), 4718593);
 }
@@ -246,19 +246,19 @@ TEST(EtlParser, StackwalkV2StackEvent)
     EXPECT_EQ(event.process_id(), 0);
     EXPECT_EQ(event.thread_id(), 0);
     EXPECT_EQ(event.stack_size(), 13);
-    EXPECT_EQ(event.stack_address(0), 18446735292148860480);
-    EXPECT_EQ(event.stack_address(1), 18446735292148861325);
-    EXPECT_EQ(event.stack_address(2), 18446735292148780791);
-    EXPECT_EQ(event.stack_address(3), 18446735292148805948);
-    EXPECT_EQ(event.stack_address(4), 18446735292148802302);
-    EXPECT_EQ(event.stack_address(5), 18446735291558407338);
-    EXPECT_EQ(event.stack_address(6), 18446735292047414145);
-    EXPECT_EQ(event.stack_address(7), 18446735292044206785);
-    EXPECT_EQ(event.stack_address(8), 18446735292044095481);
-    EXPECT_EQ(event.stack_address(9), 18446735291558412086);
-    EXPECT_EQ(event.stack_address(10), 18446735291273943482);
-    EXPECT_EQ(event.stack_address(11), 18446735291273941444);
-    EXPECT_EQ(event.stack_address(12), 18446735291275465982);
+    EXPECT_EQ(event.stack_address(0), 18446735292148860480ULL);
+    EXPECT_EQ(event.stack_address(1), 18446735292148861325ULL);
+    EXPECT_EQ(event.stack_address(2), 18446735292148780791ULL);
+    EXPECT_EQ(event.stack_address(3), 18446735292148805948ULL);
+    EXPECT_EQ(event.stack_address(4), 18446735292148802302ULL);
+    EXPECT_EQ(event.stack_address(5), 18446735291558407338ULL);
+    EXPECT_EQ(event.stack_address(6), 18446735292047414145ULL);
+    EXPECT_EQ(event.stack_address(7), 18446735292044206785ULL);
+    EXPECT_EQ(event.stack_address(8), 18446735292044095481ULL);
+    EXPECT_EQ(event.stack_address(9), 18446735291558412086ULL);
+    EXPECT_EQ(event.stack_address(10), 18446735291273943482ULL);
+    EXPECT_EQ(event.stack_address(11), 18446735291273941444ULL);
+    EXPECT_EQ(event.stack_address(12), 18446735291275465982ULL);
 }
 
 TEST(EtlParser, ImageV2LoadEventView)
@@ -275,7 +275,7 @@ TEST(EtlParser, ImageV2LoadEventView)
 
     const auto event = etl::parser::image_v2_load_event_view(std::as_bytes(std::span(buffer)), 8);
 
-    EXPECT_EQ(event.image_base(), 18446735291271086080);
+    EXPECT_EQ(event.image_base(), 18446735291271086080ULL);
     EXPECT_EQ(event.image_size(), 17068032);
     EXPECT_EQ(event.process_id(), 0);
     EXPECT_EQ(event.image_checksum(), 12051543);
@@ -304,7 +304,7 @@ TEST(EtlParser, ProcessV4TypeGroup1EventView)
 
     const auto event = etl::parser::process_v4_type_group1_event_view(std::as_bytes(std::span(buffer)), 8);
 
-    EXPECT_EQ(event.unique_process_key(), 18446672611278225600);
+    EXPECT_EQ(event.unique_process_key(), 18446672611278225600ULL);
     EXPECT_EQ(event.process_id(), 9584);
     EXPECT_EQ(event.parent_id(), 1152);
     EXPECT_EQ(event.session_id(), 0);
@@ -339,12 +339,12 @@ TEST(EtlParser, ThreadV3TypeGroup1EventView)
 
     EXPECT_EQ(event.process_id(), 0);
     EXPECT_EQ(event.thread_id(), 0);
-    EXPECT_EQ(event.stack_base(), 18446735291311304704);
-    EXPECT_EQ(event.stack_limit(), 18446735291311276032);
+    EXPECT_EQ(event.stack_base(), 18446735291311304704ULL);
+    EXPECT_EQ(event.stack_limit(), 18446735291311276032ULL);
     EXPECT_EQ(event.user_stack_base(), 0);
     EXPECT_EQ(event.user_stack_limit(), 0);
     EXPECT_EQ(event.affinity(), 1);
-    EXPECT_EQ(event.win32_start_addr(), 18446735291275465824);
+    EXPECT_EQ(event.win32_start_addr(), 18446735291275465824ULL);
     EXPECT_EQ(event.teb_base(), 0);
     EXPECT_EQ(event.sub_process_tag(), 0);
     EXPECT_EQ(event.base_priority(), 0);
@@ -363,9 +363,7 @@ TEST(EtlParser, ImageIdV2InfoEventView)
 
     const auto event = etl::parser::image_id_v2_info_event_view(std::as_bytes(std::span(buffer)), 8);
 
-    const auto fn = event.original_file_name();
-
-    EXPECT_EQ(event.image_base(), 18446735291271086080);
+    EXPECT_EQ(event.image_base(), 18446735291271086080ULL);
     EXPECT_EQ(event.image_size(), 17068032);
     EXPECT_EQ(event.process_id(), 0);
     EXPECT_EQ(event.time_date_stamp(), 0);

--- a/tests/perf_data/event_observer.cpp
+++ b/tests/perf_data/event_observer.cpp
@@ -42,8 +42,8 @@ TEST(PerfDataDispatchEventObserver, Dispatch)
         [&sample_event_called](const perf_data::parser::event_header_view& /*header*/,
                                const perf_data::parser::sample_event& event)
         {
-            EXPECT_EQ(event.ip, 140270571258003);
-            EXPECT_EQ(event.ips, (std::vector<std::uint64_t>{18446744073709551104, 140270571258003, 94208011558848}));
+            EXPECT_EQ(event.ip, 140270571258003UL);
+            EXPECT_EQ(event.ips, (std::vector<std::uint64_t>{18446744073709551104UL, 140270571258003UL, 94208011558848UL}));
 
             sample_event_called = true;
         });

--- a/tests/perf_data/parser.cpp
+++ b/tests/perf_data/parser.cpp
@@ -189,7 +189,7 @@ TEST(PerfDataParser, KernelSampleEvent)
     EXPECT_EQ(event.cpu, std::nullopt);
     EXPECT_EQ(event.res, std::nullopt);
     EXPECT_EQ(event.period, 1);
-    EXPECT_EQ(event.ips, (std::vector<std::uint64_t>{18446744073709551104, 140270571258003, 94208011558848}));
+    EXPECT_EQ(event.ips, (std::vector<std::uint64_t>{18446744073709551104ULL, 140270571258003ULL, 94208011558848ULL}));
     EXPECT_EQ(event.data, std::nullopt);
 }
 


### PR DESCRIPTION
Fix or disable all compiler warnings with MSVC and GCC and enable building with warnings as errors in the CI system.