### PR TITLE
Use exceptions to handle errors in ETL and perf.data readers

### DIFF
--- a/snail/common/chunked_reader.hpp
+++ b/snail/common/chunked_reader.hpp
@@ -2,13 +2,11 @@
 
 #include <array>
 #include <bit>
+#include <format>
 #include <fstream>
 #include <span>
+#include <stdexcept>
 #include <type_traits>
-
-// TODO: error handling. Remove includes if not required anymore
-#include <format>
-#include <iostream>
 
 namespace snail::common {
 
@@ -23,8 +21,7 @@ public:
         file_stream_.seekg(offset);
         if(!file_stream_.good() || file_stream_.tellg() != std::streampos(offset))
         {
-            std::cout << std::format("ERROR: Could not move to events data section.") << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error("Failed to move to file offset");
         }
     }
 
@@ -51,8 +48,7 @@ public:
 
         if(!file_stream_.good())
         {
-            std::cout << "ERROR: Cannot read from perf.data: File is an invalid state." << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error("Failed to read chunk from file: file is an invalid state.");
         }
 
         const auto remaining_data_bytes_to_read = remaining_data_bytes - last_chunk_remaining_bytes;
@@ -69,12 +65,10 @@ public:
 
         if(chunk_read_bytes != static_cast<std::streamoff>(chunk_bytes_to_read))
         {
-            std::cout << std::format(
-                             "ERROR: Could not read from perf.data: Expected to read {} bytes but only got {}.",
-                             chunk_bytes_to_read,
-                             chunk_read_bytes)
-                      << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error(std::format(
+                "ERROR: Could not read from file: Expected to read {} bytes but only got {}.",
+                chunk_bytes_to_read,
+                chunk_read_bytes));
         }
 
         current_chunk_data_ = std::span(chunk_buffer_.data(), chunk_read_bytes + last_chunk_remaining_bytes);

--- a/snail/perf_data/detail/attributes_database.cpp
+++ b/snail/perf_data/detail/attributes_database.cpp
@@ -15,8 +15,7 @@ void event_attributes_database::validate()
 {
     if(all_attributes.empty())
     {
-        std::cout << "Empty event attributes" << std::endl;
-        std::exit(EXIT_FAILURE); // TODO: handle error
+        throw std::runtime_error("Invalid perf.data file: empty event attributes");
     }
 
     const auto& main_attributes = all_attributes.front();
@@ -24,8 +23,7 @@ void event_attributes_database::validate()
     if(main_attributes.sample_format.test(parser::sample_format::read) &&
        !main_attributes.read_format.test(parser::read_format::id))
     {
-        std::cout << "Non matching read format" << std::endl;
-        std::exit(EXIT_FAILURE); // TODO: handle error
+        throw std::runtime_error("Invalid perf.data file: non-matching read format");
     }
 
     id_offset      = calculate_id_offset(main_attributes.sample_format);
@@ -36,22 +34,19 @@ void event_attributes_database::validate()
         if(id_offset != calculate_id_offset(attributes.sample_format) ||
            id_back_offset != calculate_id_back_offset(attributes.sample_format))
         {
-            std::cout << "ERROR: Different id positions" << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error("Invalid perf.data file: non-matching id positions");
         }
 
         if(main_attributes.flags.test(parser::attribute_flag::sample_id_all) !=
            attributes.flags.test(parser::attribute_flag::sample_id_all))
         {
-            std::cout << "ERROR: Different sample_id_all" << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error("Invalid perf.data file: non-matching sample_id_all");
         }
 
         if(main_attributes.read_format.data() !=
            attributes.read_format.data())
         {
-            std::cout << "ERROR: Different read_format" << std::endl;
-            std::exit(EXIT_FAILURE); // TODO: handle error
+            throw std::runtime_error("Invalid perf.data file: non-matching read_format");
         }
     }
 }
@@ -116,8 +111,7 @@ const parser::event_attributes& event_attributes_database::get_event_attributes(
     const auto iter = id_to_attributes.find(id);
     if(iter == id_to_attributes.end())
     {
-        std::cout << "ERROR: Could not find event attributes for ID" << std::endl;
-        std::exit(EXIT_FAILURE); // TODO: handle error
+        throw std::runtime_error("Could not find event attributes for ID");
     }
     return *iter->second;
 }


### PR DESCRIPTION
Originally it was not determined whether we need this project to be compliable without exception support. Since by now it has been decided that exceptions will be allowed we can make the ETL and perf.data readers use exceptions in exceptional error cases.