### PR TITLE
Introduce code coverage support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Install gcc-13
         if: runner.os == 'Linux'
         run: |
-          wget --no-verbose http://kayari.org/gcc-latest/gcc-latest_13.0.1-20230326git55bc61a75a68.deb
-          sudo dpkg -i gcc-latest_13.0.1-20230326git55bc61a75a68.deb
-          echo "/opt/gcc-latest/bin" >> $GITHUB_PATH
-          echo "LD_RUN_PATH=/opt/gcc-latest/lib64" >> $GITHUB_ENV
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
       - name: Install clang-17(dev)
         if: runner.os == 'Linux' && matrix.compiler == 'clang'
@@ -58,8 +58,6 @@ jobs:
           sudo apt install clang-17 llvm-17-dev
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
-          echo "CFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
-          echo "CXXFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,77 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  job:
+    name: ${{ matrix.platform }}-llvm-cov
+
+    runs-on: ${{ matrix.run-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        run-on: [ubuntu-latest]
+        include:
+          - run-on: ubuntu-latest
+            triplet: x64-linux-release
+            platform: linux
+
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
+      VCPKG_GIT_COMMIT_ID: "f6a5d4e8eb7476b8d7fc12a56dff300c1c986131"
+
+    steps:
+      - name: Install gcc-13
+        run: |
+          wget --no-verbose http://kayari.org/gcc-latest/gcc-latest_13.0.1-20230326git55bc61a75a68.deb
+          sudo dpkg -i gcc-latest_13.0.1-20230326git55bc61a75a68.deb
+          echo "/opt/gcc-latest/bin" >> $GITHUB_PATH
+          echo "LD_RUN_PATH=/opt/gcc-latest/lib64" >> $GITHUB_ENV
+
+      - name: Install clang-17(dev)
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
+          sudo apt update
+          sudo apt install clang-17 llvm-17-dev
+          echo "CC=clang-17" >> $GITHUB_ENV
+          echo "CXX=clang++-17" >> $GITHUB_ENV
+          echo "CFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
+          echo "CXXFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"
+          ninjaVersion: "^1.11.1"
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: "${{ env.VCPKG_GIT_COMMIT_ID }}"
+
+      - name: Build & Test project
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: "coverage"
+          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Debug', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm/']"
+          buildPreset: "coverage"
+          testPreset: "coverage"
+
+      - name: Coverage Report
+        run: cmake --build ${{ github.workspace }}/build/coverage --target code_coverage_report
+
+      - name: Coverage Export
+        run: cmake --build ${{ github.workspace }}/build/coverage --target code_coverage_export_lcov
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ github.workspace }}/build/coverage/coverage.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Install gcc-13
         run: |
-          wget --no-verbose http://kayari.org/gcc-latest/gcc-latest_13.0.1-20230326git55bc61a75a68.deb
-          sudo dpkg -i gcc-latest_13.0.1-20230326git55bc61a75a68.deb
-          echo "/opt/gcc-latest/bin" >> $GITHUB_PATH
-          echo "LD_RUN_PATH=/opt/gcc-latest/lib64" >> $GITHUB_ENV
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt update
+          sudo apt install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 --slave /usr/bin/g++ g++ /usr/bin/g++-13
 
       - name: Install clang-17(dev)
         run: |
@@ -41,8 +41,6 @@ jobs:
           sudo apt install clang-17 llvm-17-dev
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
-          echo "CFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
-          echo "CXXFLAGS=--gcc-toolchain=/opt/gcc-latest" >> $GITHUB_ENV
 
       - uses: actions/checkout@v3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,25 @@ cmake_minimum_required(VERSION 3.25)
 
 project(snail_support VERSION 0.1 LANGUAGES CXX C)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+# =======
+# Modules
 
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules")
 
-include(cmake/compile_options.cmake)
+include(CMakeDependentOption)
+
+include(CodeCoverage)
+
+# =======
+# Options
+
+option(BUILD_TESTING "Whether to build testing" ON)
+cmake_dependent_option(SNAIL_ENABLE_CODE_COVERAGE "Enable code coverage for tests" OFF BUILD_TESTING OFF)
 
 option(SNAIL_WITH_LLVM "Required to resolve symbols from PDB and DWARF files." ON)
+
+# =======
+# Dependencies
 
 if(SNAIL_WITH_LLVM)
   find_package(LLVM CONFIG REQUIRED
@@ -23,18 +35,35 @@ find_package(nlohmann_json CONFIG REQUIRED)
 find_package(libzippp CONFIG REQUIRED)
 
 # =======
-# LIBRARIES
+# Compile options
+
+set(CMAKE_CXX_EXTENSIONS OFF)
+include(cmake/compile_options.cmake)
+
+if(SNAIL_ENABLE_CODE_COVERAGE)
+  enable_code_coverage()
+endif()
+
+# =======
+# Targets
 
 add_subdirectory(snail)
 
 # =======
-# TESTS
+# Tests
 
-enable_testing()
+if(BUILD_TESTING)
+  enable_testing()
 
-add_subdirectory(third-party/gtest)
+  add_subdirectory(third-party/gtest)
 
-add_subdirectory(tests/unit)
+  add_subdirectory(tests/unit)
 
-# Just for testing/development
-add_subdirectory(apps)
+  # Just for testing/development
+  add_subdirectory(apps)
+endif()
+
+string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _SOURCE_DIR_REGEX "${PROJECT_SOURCE_DIR}")
+code_coverage_report(
+  EXCLUDE "${_SOURCE_DIR_REGEX}/tests/"
+)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,6 +22,23 @@
                     "value": "ON"
                 }
             }
+        },
+        {
+            "name": "coverage",
+            "displayName": "Configure for CI coverage",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "generator": "Ninja",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "cacheVariables": {
+                "CMAKE_MSVC_RUNTIME_LIBRARY": {
+                    "type": "STRING",
+                    "value": "MultiThreaded"
+                },
+                "SNAIL_ENABLE_CODE_COVERAGE": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
         }
     ],
     "buildPresets": [
@@ -29,12 +46,24 @@
             "name": "ci",
             "configurePreset": "ci",
             "displayName": "Build for CI"
+        },
+        {
+            "name": "coverage",
+            "configurePreset": "coverage",
+            "displayName": "Build for coverage CI"
         }
     ],
     "testPresets": [
         {
             "name": "ci",
             "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "coverage",
+            "configurePreset": "coverage",
             "output": {
                 "outputOnFailure": true
             }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Snail Server
 
 [![CI](https://github.com/albertziegenhagel/snail-server/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/albertziegenhagel/snail-server/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/albertziegenhagel/snail-server/branch/main/graph/badge.svg?token=8Y7KBNIM5K)](https://codecov.io/gh/albertziegenhagel/snail-server)
 
 This is the native server backend for the VS Code extension [Snail](https://github.com/albertziegenhagel/snail).

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,10 +1,10 @@
 
 
 add_executable(app_etl_file etl_file.cpp)
-target_link_libraries(app_etl_file compile_options etl)
+target_link_libraries(app_etl_file PRIVATE compile_options etl)
 
 add_executable(app_perf_data_file perf_data_file.cpp)
-target_link_libraries(app_perf_data_file compile_options perf_data)
+target_link_libraries(app_perf_data_file PRIVATE compile_options perf_data)
 
 add_executable(app_analysis analysis.cpp)
-target_link_libraries(app_analysis compile_options analysis)
+target_link_libraries(app_analysis PRIVATE compile_options analysis)

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -1,0 +1,202 @@
+
+function(enable_code_coverage)
+  get_property(_coverage_enabled GLOBAL PROPERTY "_CodeCoverage_enabled")
+  if(_coverage_enabled)
+    return()
+  endif()
+
+  set(_compile_options)
+  set(_link_options)
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    get_filename_component(_compiler_path "${CMAKE_CXX_COMPILER}" PATH)
+    string(REGEX MATCH "^[0-9]+.[0-9]+" _llvm_version "${CMAKE_CXX_COMPILER_VERSION}")
+
+    find_program(
+      LLVM_PROFDATA_PATH
+      NAMES "llvm-profdata" "llvm-profdata-${_llvm_version}"
+      HINTS ${_compiler_path}
+    )
+    if(NOT LLVM_PROFDATA_PATH)
+      message(SEND_ERROR "Missing: LLVM_PROFDATA_PATH")
+    endif()
+
+    find_program(
+      LLVM_COV_PATH
+      NAMES "llvm-cov" "llvm-cov-${_llvm_version}"
+      HINTS ${_compiler_path}
+    )
+    if(NOT LLVM_COV_PATH)
+      message(SEND_ERROR "Missing: LLVM_COV_PATH")
+    endif()
+
+    # set(_pass_through_prefix)
+    # if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    #   set(_pass_through_prefix "/clang:")
+    # endif()
+    # list(APPEND _compile_options
+    #   "${_pass_through_prefix}-fprofile-arcs"
+    #   "${_pass_through_prefix}-ftest-coverage"
+    # )
+    # list(APPEND _link_options
+    #   "-fprofile-arcs"
+    #   "-ftest-coverage"
+    # )
+
+    list(APPEND _compile_options
+      "-fprofile-instr-generate"
+      "-fcoverage-mapping"
+      # -mllvm -runtime-counter-relocation
+    )
+    list(APPEND _link_options
+      "-fprofile-instr-generate"
+      "-fcoverage-mapping"
+      # -mllvm -runtime-counter-relocation
+    )
+
+    # Workaround and issue with picking up incorrect profiler libraries. See:
+    #   https://youtrack.jetbrains.com/issue/CPP-29577
+    if("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
+      execute_process(
+          COMMAND "${CMAKE_CXX_COMPILER}" "/clang:--print-search-dirs"
+          OUTPUT_VARIABLE _search_dirs
+          COMMAND_ERROR_IS_FATAL ANY
+      )
+      string(STRIP "${_search_dirs}" _search_dirs)
+      string(REGEX REPLACE "^programs: =.*libraries: =(.+)$" "\\1" _lib_path "${_search_dirs}")
+      if(_lib_path)
+        file(TO_CMAKE_PATH "${_lib_path}" _lib_path)
+        cmake_path(APPEND _lib_path "lib" "windows")
+        if(EXISTS "${_lib_path}")
+          file(TO_NATIVE_PATH "${_lib_path}" _lib_path)
+          list(APPEND _link_options "/LIBPATH:${_lib_path}")
+        endif()
+      endif()
+    endif()
+  elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    get_filename_component(_compiler_path "${CMAKE_CXX_COMPILER}" PATH)
+    string(REGEX MATCH "^[0-9]+" _gcc_version "${CMAKE_CXX_COMPILER_VERSION}")
+
+    find_program(
+      GCOV_PATH
+      NAMES "gcov" "gcov-${_gcc_version}"
+      HINTS ${_compiler_path}
+    )
+    if(NOT GCOV_PATH)
+      message(SEND_ERROR "Missing: GCOV_PATH")
+    endif()
+
+    list(APPEND _compile_options
+      "-fprofile-arcs"
+      "-ftest-coverage"
+    )
+    list(APPEND _link_options
+      "-fprofile-arcs"
+      "-ftest-coverage"
+    )
+  else()
+    message(FATAL_ERROR "Code coverage is only support for clang and gcc.\n"
+                        "Please choose another compiler or disable code coverage.")
+  endif()
+  
+  add_library(code_coverage_options INTERFACE)
+  target_compile_options(code_coverage_options INTERFACE ${_compile_options})
+  target_link_options(code_coverage_options INTERFACE ${_link_options})
+
+  set_property(GLOBAL PROPERTY "_CodeCoverage_enabled" TRUE)
+  set_property(GLOBAL PROPERTY "_CodeCoverage_targets" "")
+endfunction()
+
+function(code_coverage_add_target TARGET)
+  get_property(_coverage_enabled GLOBAL PROPERTY "_CodeCoverage_enabled")
+  if(NOT _coverage_enabled)
+    return()
+  endif()
+
+  set_property(GLOBAL APPEND PROPERTY "_CodeCoverage_targets" "${TARGET}")
+
+  target_link_libraries(${TARGET} PRIVATE code_coverage_options)
+endfunction()
+
+function(code_coverage_setup_discovered_tests TARGET)
+  get_property(_coverage_enabled GLOBAL PROPERTY "_CodeCoverage_enabled")
+  if(NOT _coverage_enabled)
+    return()
+  endif()
+  
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(test_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_code_coverage_environment.cmake")
+    file(GENERATE
+      OUTPUT  "${test_include_file}"
+      CONTENT "\
+      foreach(test_name IN LISTS ${TARGET}_TESTS)\n\
+        string(REPLACE \":\" \"_\" file_name \"\${test_name}\")\n\
+        set_tests_properties(\${test_name} PROPERTIES ENVIRONMENT \"LLVM_PROFILE_FILE=code_coverage/\${file_name}.profraw\")\n\
+      endforeach()\n"
+    )
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/code_coverage") # TODO: this should be the working directory of the test
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} APPEND PROPERTY TEST_INCLUDE_FILES "${test_include_file}")
+  endif()
+endfunction()
+
+function(code_coverage_report)
+  cmake_parse_arguments(_args "" "EXCLUDE" "" ${ARGN})
+
+  get_property(_coverage_enabled GLOBAL PROPERTY "_CodeCoverage_enabled")
+  if(NOT _coverage_enabled)
+    return()
+  endif()
+
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(_all_objects)
+    get_property(_targets GLOBAL PROPERTY "_CodeCoverage_targets")
+    foreach(target_name IN LISTS _targets)
+      list(APPEND _all_objects
+        -object "$<TARGET_FILE:${target_name}>"
+      )
+    endforeach()
+
+    set(_data_dir "${CMAKE_BINARY_DIR}/tests/unit/code_coverage") # TODO: detect these
+
+    file(WRITE "${CMAKE_BINARY_DIR}/find-profdata-files.cmake"
+      "file(GLOB_RECURSE profdata_files\n"
+      "  LIST_DIRECTORIES FALSE\n"
+      "  \"${_data_dir}/*.profraw\"\n"
+      ")\n"
+      "set(_content)\n"
+      "foreach(file IN LISTS profdata_files)\n"
+      "  set(_content \"\${_content}\${file}\\n\")\n"
+      "endforeach()\n"
+      "file(WRITE \"${CMAKE_BINARY_DIR}/all-profdata-inputs.txt\"\n"
+      "  \"\${_content}\"\n"
+      ")\n"
+    )
+
+    add_custom_target(code_coverage_merge
+      COMMAND ${CMAKE_COMMAND} -P find-profdata-files.cmake
+      COMMAND ${LLVM_PROFDATA_PATH} merge -sparse --output=merged.profdata --input-files=all-profdata-inputs.txt
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMENT "Merge code coverage profile data..."
+    )
+
+    set(additional_report_args)
+    if(_args_EXCLUDE)
+      list(APPEND additional_report_args "--ignore-filename-regex=\"${_args_EXCLUDE}\"")
+    endif()
+
+    add_custom_target(code_coverage_report
+      DEPENDS code_coverage_merge
+      COMMAND ${LLVM_COV_PATH} report ${additional_report_args} --instr-profile=merged.profdata ${_all_objects}
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+
+    add_custom_target(code_coverage_export_lcov
+      DEPENDS code_coverage_merge
+      COMMAND ${LLVM_COV_PATH} export ${additional_report_args} --format=lcov --instr-profile=merged.profdata ${_all_objects} > coverage.info
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      COMMENT "Export LCOV code coverage data..."
+    )
+  else()
+    add_custom_target(coverage_report)
+    add_custom_target(coverage_export)
+  endif()
+endfunction()

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -10,11 +10,16 @@ function(enable_code_coverage)
   if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     get_filename_component(_compiler_path "${CMAKE_CXX_COMPILER}" PATH)
     string(REGEX MATCH "^[0-9]+.[0-9]+" _llvm_version "${CMAKE_CXX_COMPILER_VERSION}")
+    string(REGEX MATCH "^[0-9]+" _llvm_version_major "${CMAKE_CXX_COMPILER_VERSION}")
 
     find_program(
       LLVM_PROFDATA_PATH
-      NAMES "llvm-profdata" "llvm-profdata-${_llvm_version}"
-      HINTS ${_compiler_path}
+      NAMES
+        "llvm-profdata-${_llvm_version}"
+        "llvm-profdata-${_llvm_version_major}"
+        "llvm-profdata"
+      HINTS
+        "${_compiler_path}"
     )
     if(NOT LLVM_PROFDATA_PATH)
       message(SEND_ERROR "Missing: LLVM_PROFDATA_PATH")
@@ -22,8 +27,12 @@ function(enable_code_coverage)
 
     find_program(
       LLVM_COV_PATH
-      NAMES "llvm-cov" "llvm-cov-${_llvm_version}"
-      HINTS ${_compiler_path}
+      NAMES
+        "llvm-cov-${_llvm_version}"
+        "llvm-cov-${_llvm_version_major}"
+        "llvm-cov"
+      HINTS
+        "${_compiler_path}"
     )
     if(NOT LLVM_COV_PATH)
       message(SEND_ERROR "Missing: LLVM_COV_PATH")

--- a/snail/analysis/CMakeLists.txt
+++ b/snail/analysis/CMakeLists.txt
@@ -55,3 +55,5 @@ target_include_directories(analysis SYSTEM PRIVATE
 )
 
 target_include_directories(analysis PUBLIC ${CMAKE_SOURCE_DIR})
+
+code_coverage_add_target(analysis)

--- a/snail/common/CMakeLists.txt
+++ b/snail/common/CMakeLists.txt
@@ -14,3 +14,5 @@ target_link_libraries(common
 )
 
 target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR})
+
+code_coverage_add_target(common)

--- a/snail/etl/CMakeLists.txt
+++ b/snail/etl/CMakeLists.txt
@@ -15,3 +15,5 @@ target_link_libraries(etl
 )
 
 target_include_directories(etl PUBLIC ${CMAKE_SOURCE_DIR})
+
+code_coverage_add_target(etl)

--- a/snail/jsonrpc/CMakeLists.txt
+++ b/snail/jsonrpc/CMakeLists.txt
@@ -39,3 +39,5 @@ target_link_libraries(jsonrpc
 )
 
 target_include_directories(jsonrpc PUBLIC ${CMAKE_SOURCE_DIR})
+
+code_coverage_add_target(jsonrpc)

--- a/snail/perf_data/CMakeLists.txt
+++ b/snail/perf_data/CMakeLists.txt
@@ -20,3 +20,5 @@ target_link_libraries(perf_data
 )
 
 target_include_directories(perf_data PUBLIC ${CMAKE_SOURCE_DIR})
+
+code_coverage_add_target(perf_data)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -21,10 +21,11 @@ function(add_unit_test_executable TEST_NAME)
   )
 
   target_link_libraries(test_${TEST_NAME}
-    compile_options
-    test_main
-    GTest::gtest
-    ${args_DEPENDENCIES}
+    PRIVATE
+      compile_options
+      test_main
+      GTest::gtest
+      ${args_DEPENDENCIES}
   )
 
   target_include_directories(test_${TEST_NAME}
@@ -32,10 +33,13 @@ function(add_unit_test_executable TEST_NAME)
       "${CMAKE_CURRENT_SOURCE_DIR}"
   )
 
+  code_coverage_add_target(test_${TEST_NAME})
+
   cmake_path(NATIVE_PATH CMAKE_SOURCE_DIR native_source_dir)
   gtest_discover_tests(test_${TEST_NAME}
     EXTRA_ARGS "--snail-root-dir=${native_source_dir}"
   )
+  code_coverage_setup_discovered_tests(test_${TEST_NAME})
 endfunction()
 
 add_unit_test_executable(common


### PR DESCRIPTION
This adds support for code coverage for the unit tests to the CMake files and enables it as GitHub action check.

Code coverage can be enabled via `-DSNAIL_ENABLE_CODE_COVERAGE`. Currently it does only work with clang (using `llvm-cov`) on linux.