### PR TITLE
Add clang format check as GitHub action

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,30 @@
+name: clang-format Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  
+jobs:
+  job:
+    name: Check clang-format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run clang-format
+      uses: DoozyX/clang-format-lint-action@v0.16.2
+      with:
+        source: './snail ./tests'
+        exclude: './snail/common/third_party'
+        extensions: 'cpp,hpp'
+        clangFormatVersion: 16
+
+    # - uses: EndBug/add-and-commit@v9
+    #   with:
+    #     author_name: Clang Robot
+    #     author_email: robot@example.com
+    #     message: 'Committing clang-format changes'
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/snail/analysis/detail/module_map.cpp
+++ b/snail/analysis/detail/module_map.cpp
@@ -17,7 +17,7 @@ struct module_map::address_range
     struct module_entry
     {
         common::timestamp_t load_timestamp;
-        std::size_t       module_index;
+        std::size_t         module_index;
     };
 
     // Sorted by load_timestamp (from oldest to newest)

--- a/snail/common/unicode.cpp
+++ b/snail/common/unicode.cpp
@@ -43,7 +43,7 @@ std::basic_string<Utf8Char> snail::common::utf16_to_utf8(std::u16string_view inp
     return result_string;
 #else
     // FIXME: do not rely on deprecated functionality
-    auto convert = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{};
+    auto       convert       = std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>{};
     const auto result_string = convert.to_bytes(input.data(), input.data() + input.size());
 
     if constexpr(std::is_same_v<Utf8Char, char>)
@@ -58,5 +58,5 @@ std::basic_string<Utf8Char> snail::common::utf16_to_utf8(std::u16string_view inp
 #endif
 }
 
-template std::basic_string<char> snail::common::utf16_to_utf8<char>(std::u16string_view);
+template std::basic_string<char>    snail::common::utf16_to_utf8<char>(std::u16string_view);
 template std::basic_string<char8_t> snail::common::utf16_to_utf8<char8_t>(std::u16string_view);

--- a/snail/perf_data/dispatching_event_observer.hpp
+++ b/snail/perf_data/dispatching_event_observer.hpp
@@ -24,10 +24,10 @@ template<typename T>
 concept parsable_event_record = requires(const parser::event_attributes& attributes,
                                          std::span<const std::byte>      buffer,
                                          std::endian                     byte_order) {
-                                    {
-                                        parser::parse_event<T>(attributes, buffer, byte_order)
-                                        } -> std::same_as<T>;
-                                };
+    {
+        parser::parse_event<T>(attributes, buffer, byte_order)
+    } -> std::same_as<T>;
+};
 
 template<typename T, typename EventType>
 concept event_handler = std::invocable<T, parser::event_header_view, EventType>;

--- a/tests/unit/jsonrpc/pipe.cpp
+++ b/tests/unit/jsonrpc/pipe.cpp
@@ -59,7 +59,7 @@ TEST(PipeIoStream, ConstructOpen)
 
 TEST(PipeIoStream, ConstructOpenInvalid)
 {
-    const auto* const pipe_path = R"(\\.\pipe\snail-non-existing-pipe)";
+    const auto* const   pipe_path = R"(\\.\pipe\snail-non-existing-pipe)";
     const pipe_iostream stream(pipe_path);
     EXPECT_FALSE(stream.is_open());
 }


### PR DESCRIPTION
Adds a GitHub action to check for clang-format violations and fixes current formatting errors