### PR TITLE
Uploaded binaries to "latest" release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+  deployments: write
+
 jobs:
-  job:
+  build:
     name: ${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.compiler }}
 
     runs-on: ${{ matrix.run-on }}
@@ -157,3 +161,9 @@ jobs:
         with:
           name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}
           path: ${{ github.workspace }}/install/bin/snail-server*
+
+  deploy-head:
+    name: "Deploy head"
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy-head.yml

--- a/.github/workflows/deploy-head.yml
+++ b/.github/workflows/deploy-head.yml
@@ -1,0 +1,85 @@
+name: "Deploy head"
+
+on:
+  workflow_call
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  tag:
+    name: "Update tag"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Update head tag"
+        run: |
+          git push --delete origin head
+          git tag head
+          git push origin head
+
+  assets:
+    name: "Upload assets"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows, linux]
+        include:
+          - platform: windows
+            arch: x86_64
+            release-ext: zip
+            release-type: application/zip
+          - platform: linux
+            arch: x86_64
+            release-ext: tar.gz
+            release-type: application/gzip
+
+    steps:
+      - name: Download build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ci.yml
+          workflow_conclusion: success
+          branch: ${{ github.ref_name }}
+          name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}
+          path: bin
+          check_artifacts:  true
+          search_artifacts: true
+
+      - name: Pack & upload release asset
+        shell: pwsh
+        run: |
+          Compress-Archive -Path ${{ github.workspace }}/bin/* -Destination snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}
+
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/snail-server/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: ${{ matrix.release-type }}" `
+          --data-binary "@snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}" `
+          "https://uploads.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets?name=snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}"


### PR DESCRIPTION
Adds a GitHub workflow that will upload the build artifacts for builds on `main` as release assets on the `head` rolling release.