### PR TITLE
Fix image load event view

### DIFF
--- a/apps/etl_file.cpp
+++ b/apps/etl_file.cpp
@@ -94,10 +94,10 @@ int main(int /*argc*/, char* /*argv*/[])
         {
             [[maybe_unused]] const auto process_id = event.process_id();
         });
-    observer.register_event<etl::parser::image_v2_load_event_view>(
+    observer.register_event<etl::parser::image_v3_load_event_view>(
         [](const etl::etl_file::header_data& /*file_header*/,
            const etl::common_trace_header& /*header*/,
-           const etl::parser::image_v2_load_event_view& event)
+           const etl::parser::image_v3_load_event_view& event)
         {
             [[maybe_unused]] const auto image_base = event.image_base();
         });

--- a/snail/analysis/detail/etl_file_process_context.cpp
+++ b/snail/analysis/detail/etl_file_process_context.cpp
@@ -242,8 +242,8 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
     });
 }
 
-void etl_file_process_context::handle_event(const etl::etl_file::header_data& file_header,
-                                            const etl::common_trace_header& /*header*/,
+void etl_file_process_context::handle_event(const etl::etl_file::header_data&                 file_header,
+                                            [[maybe_unused]] const etl::common_trace_header&  header,
                                             const etl::parser::stackwalk_v2_stack_event_view& event)
 {
     const auto process_id = event.process_id();

--- a/snail/analysis/detail/etl_file_process_context.cpp
+++ b/snail/analysis/detail/etl_file_process_context.cpp
@@ -38,7 +38,7 @@ etl_file_process_context::etl_file_process_context()
     register_event<etl::parser::system_config_v5_pnp_event_view>();
     register_event<etl::parser::process_v4_type_group1_event_view>();
     register_event<etl::parser::thread_v3_type_group1_event_view>();
-    register_event<etl::parser::image_v2_load_event_view>();
+    register_event<etl::parser::image_v3_load_event_view>();
     register_event<etl::parser::perfinfo_v2_sampled_profile_event_view>();
     register_event<etl::parser::stackwalk_v2_stack_event_view>();
     register_event<etl::parser::vs_diagnostics_hub_target_profiling_started_event_view>();
@@ -208,7 +208,7 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
 
 void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*file_header*/,
                                             const etl::common_trace_header&              header,
-                                            const etl::parser::image_v2_load_event_view& event)
+                                            const etl::parser::image_v3_load_event_view& event)
 {
     if(header.type != 10 && header.type != 3) return; // We do only handle load events
 

--- a/snail/analysis/detail/etl_file_process_context.hpp
+++ b/snail/analysis/detail/etl_file_process_context.hpp
@@ -24,7 +24,7 @@ struct system_config_v2_logical_disk_event_view;
 struct system_config_v5_pnp_event_view;
 struct process_v4_type_group1_event_view;
 struct thread_v3_type_group1_event_view;
-struct image_v2_load_event_view;
+struct image_v3_load_event_view;
 struct perfinfo_v2_sampled_profile_event_view;
 struct stackwalk_v2_stack_event_view;
 struct vs_diagnostics_hub_target_profiling_started_event_view;
@@ -112,7 +112,7 @@ private:
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v5_pnp_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::process_v4_type_group1_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::thread_v3_type_group1_event_view& event);
-    void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::image_v2_load_event_view& event);
+    void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::image_v3_load_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::perfinfo_v2_sampled_profile_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::stackwalk_v2_stack_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::vs_diagnostics_hub_target_profiling_started_event_view& event);

--- a/snail/etl/parser/records/kernel/image.hpp
+++ b/snail/etl/parser/records/kernel/image.hpp
@@ -19,7 +19,7 @@ namespace snail::etl::parser {
 
 // See https://learn.microsoft.com/en-us/windows/win32/etw/image-load
 // or `Image_Load:Image` from wmicore.mof in WDK 10.0.22621.0
-struct image_v2_load_event_view : private extract_view_dynamic_base
+struct image_v3_load_event_view : private extract_view_dynamic_base
 {
     static inline constexpr std::uint16_t event_version = 3;
     static inline constexpr auto          event_types   = std::array{
@@ -39,12 +39,12 @@ struct image_v2_load_event_view : private extract_view_dynamic_base
 
     inline auto image_checksum() const { return extract<std::uint32_t>(dynamic_offset(4, 2)); }
 
-    inline auto time_date_stamp() const { return extract<std::uint8_t>(dynamic_offset(8, 2)); }
+    inline auto time_date_stamp() const { return extract<std::uint32_t>(dynamic_offset(8, 2)); }
 
-    inline auto signature_level() const { return extract<std::uint8_t>(dynamic_offset(9, 2)); }
-    inline auto signature_type() const { return extract<std::uint16_t>(dynamic_offset(10, 2)); }
+    inline auto signature_level() const { return extract<std::uint8_t>(dynamic_offset(12, 2)); }
+    inline auto signature_type() const { return extract<std::uint8_t>(dynamic_offset(13, 2)); }
 
-    // inline auto reserved_0() const { return extract<std::uint32_t>(dynamic_offset(12, 2)); }
+    // inline auto reserved_0() const { return extract<std::uint16_t>(dynamic_offset(14, 2)); }
 
     inline auto default_base() const { return extract<std::uint64_t>(dynamic_offset(16, 2)); }
 

--- a/tests/unit/etl/parser.cpp
+++ b/tests/unit/etl/parser.cpp
@@ -274,15 +274,15 @@ TEST(EtlParser, ImageV2LoadEventView)
         0x5c, 0x00, 0x6e, 0x00, 0x74, 0x00, 0x6f, 0x00, 0x73, 0x00, 0x6b, 0x00, 0x72, 0x00, 0x6e, 0x00,
         0x6c, 0x00, 0x2e, 0x00, 0x65, 0x00, 0x78, 0x00, 0x65, 0x00, 0x00, 0x00};
 
-    const auto event = etl::parser::image_v2_load_event_view(std::as_bytes(std::span(buffer)), 8);
+    const auto event = etl::parser::image_v3_load_event_view(std::as_bytes(std::span(buffer)), 8);
 
     EXPECT_EQ(event.image_base(), 18446735291271086080ULL);
     EXPECT_EQ(event.image_size(), 17068032);
     EXPECT_EQ(event.process_id(), 0);
     EXPECT_EQ(event.image_checksum(), 12051543);
-    EXPECT_EQ(event.time_date_stamp(), 147);
-    EXPECT_EQ(event.signature_level(), 90);
-    EXPECT_EQ(event.signature_type(), 62843);
+    EXPECT_EQ(event.time_date_stamp(), 4118502035);
+    EXPECT_EQ(event.signature_level(), 0);
+    EXPECT_EQ(event.signature_type(), 1);
     EXPECT_EQ(event.default_base(), 0);
     EXPECT_EQ(event.file_name(), std::u16string(u"\\SystemRoot\\system32\\ntoskrnl.exe"));
 }


### PR DESCRIPTION
While the name suggested it was the version 2 event, it was actually matching for version 3 events and the structure was somewhere in between.

This has now been fixed to consistently represent the version 3 event.