### PR TITLE
Refactor parser code

### DIFF
--- a/snail/common/parser/extract.hpp
+++ b/snail/common/parser/extract.hpp
@@ -49,6 +49,13 @@ T extract(std::span<const std::byte> data, std::size_t bytes_offset, std::endian
     return static_cast<T>(extract<std::underlying_type_t<T>>(data, bytes_offset, data_byte_order));
 }
 
+inline std::uint64_t extract_pointer(std::span<const std::byte> data, std::size_t bytes_offset, std::size_t pointer_size, std::endian data_byte_order)
+{
+    if(pointer_size == 4) return extract<std::uint32_t>(data, bytes_offset, data_byte_order);
+    assert(pointer_size == 8);
+    return extract<std::uint64_t>(data, bytes_offset, data_byte_order);
+}
+
 template<typename T>
     requires std::is_integral_v<T>
 inline T extract_move(std::span<const std::byte> buffer, std::size_t& bytes_offset, std::endian byte_order)

--- a/snail/etl/etl_file.cpp
+++ b/snail/etl/etl_file.cpp
@@ -22,7 +22,7 @@
 #include <snail/etl/parser/trace_headers/perfinfo_trace.hpp>
 #include <snail/etl/parser/trace_headers/system_trace.hpp>
 
-using namespace snail::common;
+using namespace snail;
 using namespace snail::etl;
 
 namespace {
@@ -70,7 +70,7 @@ buffer_info read_buffer(std::ifstream&                          file_stream,
                         std::array<std::byte, max_buffer_size>& buffer_data)
 {
     file_stream.seekg(buffer_start_pos);
-    file_stream.read(reinterpret_cast<char*>(buffer_data.data()), narrow_cast<std::streamsize>(buffer_data.size()));
+    file_stream.read(reinterpret_cast<char*>(buffer_data.data()), common::narrow_cast<std::streamsize>(buffer_data.size()));
 
     const auto read_bytes = file_stream.tellg() - buffer_start_pos;
     if(read_bytes < static_cast<std::streamoff>(parser::wmi_buffer_header_view::static_size))

--- a/snail/etl/parser/extract.hpp
+++ b/snail/etl/parser/extract.hpp
@@ -7,109 +7,20 @@
 #include <span>
 #include <string>
 
+#include <snail/common/parser/extract.hpp>
+
 namespace snail::etl::parser {
 
 // ETL files are written on Windows, hence they are always little-endian.
 inline constexpr auto etl_file_byte_order = std::endian::little;
 
-// Extract a value of integral type `T` in the native byte order starting at
-// the offset `bytes_offset` in the buffer `data` that is in `etl_file_byte_order`.
-//
-// Precondition: There have to be enough bytes in the buffer.
-template<typename T>
-    requires std::is_integral_v<T>
-T extract(std::span<const std::byte> data, std::size_t bytes_offset, std::endian data_byte_order)
-{
-    assert(bytes_offset + sizeof(T) <= data.size());
-
-    auto value = *reinterpret_cast<const T*>(data.data() + bytes_offset);
-    if(data_byte_order != std::endian::native)
-    {
-        return std::byteswap(value);
-    }
-    else
-    {
-        return value;
-    }
-}
-
-template<typename T>
-    requires std::is_integral_v<T>
-T extract(std::span<const std::byte> data, std::size_t bytes_offset)
-{
-    return extract<T>(data, bytes_offset, etl_file_byte_order);
-}
-
-// Extract a value of enum type `T` in the native byte order starting at
-// the offset `bytes_offset` in the buffer `data` that is in `etl_file_byte_order`.
-//
-// Precondition: There have to be enough bytes in the buffer.
-template<typename T>
-    requires std::is_enum_v<T>
-T extract(std::span<const std::byte> data, std::size_t bytes_offset)
-{
-    return static_cast<T>(extract<std::underlying_type_t<T>>(data, bytes_offset));
-}
-
-template<typename CharIntType>
-inline std::size_t detect_string_length(std::span<const std::byte> data, std::size_t bytes_offset)
-{
-    std::size_t size = 0;
-    while(size * sizeof(CharIntType) < data.size())
-    {
-        if(extract<CharIntType>(data, bytes_offset + size * sizeof(CharIntType)) == 0) break;
-        ++size;
-    }
-    assert(size * sizeof(CharIntType) < data.size()); // we could not find a null-terminated string
-    return size;
-}
-
-inline std::uint64_t extract_pointer(std::span<const std::byte> data, std::size_t bytes_offset, std::size_t pointer_size)
-{
-    if(pointer_size == 4) return extract<std::uint32_t>(data, bytes_offset);
-    assert(pointer_size == 8);
-    return extract<std::uint64_t>(data, bytes_offset);
-}
-
-struct extract_view_base
+// This is basically just the `extract_view_base` from the `common::parser`
+// with the byte order assumed to be `etl_file_byte_order`.
+struct extract_view_base : protected common::parser::extract_view_base
 {
     inline explicit extract_view_base(std::span<const std::byte> buffer) :
-        buffer_(buffer)
+        common::parser::extract_view_base(buffer, etl_file_byte_order)
     {}
-
-protected:
-    template<typename T>
-    inline T extract(std::size_t bytes_offset) const
-    {
-        return parser::extract<T>(buffer_, bytes_offset);
-    }
-
-    inline std::string_view extract_string(std::size_t bytes_offset, std::optional<std::size_t>& string_length) const
-    {
-        const auto* const chars = reinterpret_cast<const char*>(buffer_.data() + bytes_offset);
-        if(!string_length) string_length = detect_string_length<std::uint8_t>(buffer_, bytes_offset);
-        return std::string_view(chars, *string_length);
-    }
-
-    inline std::u16string_view extract_u16string(std::size_t bytes_offset, std::optional<std::size_t>& string_length) const
-    {
-        // Just a stupid sanity check. Actually this should never be able to be false, since
-        // if the platform provides a std::uint16_t, char16_t has to be 16 bits wide as well
-        // and we do not support a platform without std::uint16_t anyways.
-        static_assert(sizeof(char16_t) == sizeof(std::uint16_t));
-
-        const auto* const chars = reinterpret_cast<const char16_t*>(buffer_.data() + bytes_offset);
-        if(!string_length) string_length = detect_string_length<std::uint16_t>(buffer_, bytes_offset);
-        return std::u16string_view(chars, *string_length);
-    }
-
-    inline std::span<const std::byte> buffer() const
-    {
-        return buffer_;
-    }
-
-private:
-    std::span<const std::byte> buffer_;
 };
 
 struct extract_view_dynamic_base : protected extract_view_base
@@ -131,7 +42,7 @@ protected:
 
     inline std::uint64_t extract_pointer(std::size_t bytes_offset) const
     {
-        return parser::extract_pointer(buffer(), bytes_offset, pointer_size_);
+        return common::parser::extract_pointer(buffer(), bytes_offset, pointer_size_, byte_order());
     }
 
     inline std::uint32_t pointer_size() const

--- a/snail/etl/parser/records/kernel/header.hpp
+++ b/snail/etl/parser/records/kernel/header.hpp
@@ -26,7 +26,7 @@ struct event_trace_v2_header_event_view : private extract_view_dynamic_base
     };
 
     inline explicit event_trace_v2_header_event_view(std::span<const std::byte> buffer) :
-        extract_view_dynamic_base(buffer, parser::extract<std::uint32_t>(buffer, 44))
+        extract_view_dynamic_base(buffer, common::parser::extract<std::uint32_t>(buffer, 44, etl_file_byte_order))
     {}
 
     using extract_view_dynamic_base::buffer;

--- a/snail/etl/parser/records/visual_studio/diagnostics_hub.hpp
+++ b/snail/etl/parser/records/visual_studio/diagnostics_hub.hpp
@@ -22,6 +22,13 @@ constexpr inline auto vs_diagnostics_hub_guid = guid{
     0x9e5f9046, 0x43c6, 0x4f62, {0xba, 0x13, 0x7b, 0x19, 0x89, 0x62, 0x53, 0xff}
 };
 
+enum class counter_type : std::uint32_t
+{
+    unknown      = 0,
+    PrivateBytes = 1,
+    CPU          = 2
+};
+
 enum class target_start_reason : std::uint32_t
 {
     app_package_launch = 0,
@@ -91,9 +98,9 @@ struct vs_diagnostics_hub_counter_info_event_view : private extract_view_dynamic
 
     using extract_view_dynamic_base::extract_view_dynamic_base;
 
-    inline auto counter() const { return extract<std::uint32_t>(dynamic_offset(0, 0)); }
+    inline auto counter() const { return extract<counter_type>(dynamic_offset(0, 0)); }
     inline auto timestamp() const { return extract<std::uint64_t>(dynamic_offset(4, 0)); }
-    // inline auto counter() const { return extract<double>(dynamic_offset(12, 0)); }
+    inline auto value() const { return extract<double>(dynamic_offset(12, 0)); }
 };
 
 struct vs_diagnostics_hub_mark_info_event_view : private extract_view_dynamic_base

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ function(add_unit_test_executable TEST_NAME)
       compile_options
       test_main
       GTest::gtest
+      GTest::gmock
       ${args_DEPENDENCIES}
   )
 
@@ -44,6 +45,7 @@ endfunction()
 
 add_unit_test_executable(common
   SOURCES
+    common/parser.cpp
     common/utility.cpp
   DEPENDENCIES
     common

--- a/tests/unit/common/parser.cpp
+++ b/tests/unit/common/parser.cpp
@@ -1,0 +1,164 @@
+
+#include <snail/common/parser/extract.hpp>
+
+#include <array>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace snail::common::parser;
+
+enum class TestEnum : std::int16_t
+{
+    A = 0x0001,
+    B = 0x0100
+};
+
+TEST(ParserExtract, Int8)
+{
+    const std::array<std::uint8_t, 2> data = {
+        0x42, 0xAF};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<std::uint8_t>(buffer, 0, std::endian::little), 66);
+    EXPECT_EQ(extract<std::int8_t>(buffer, 0, std::endian::little), 66);
+    EXPECT_EQ(extract<std::uint8_t>(buffer, 1, std::endian::little), 175);
+    EXPECT_EQ(extract<std::int8_t>(buffer, 1, std::endian::little), -81);
+
+    EXPECT_EQ(extract<std::uint8_t>(buffer, 0, std::endian::big), 66);
+    EXPECT_EQ(extract<std::int8_t>(buffer, 0, std::endian::big), 66);
+    EXPECT_EQ(extract<std::uint8_t>(buffer, 1, std::endian::big), 175);
+    EXPECT_EQ(extract<std::int8_t>(buffer, 1, std::endian::big), -81);
+}
+
+TEST(ParserExtract, Int16)
+{
+    const std::array<std::uint8_t, 4> data = {
+        0x42, 0xAF, 0xEA, 0x20};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<std::uint16_t>(buffer, 0, std::endian::little), 44866);
+    EXPECT_EQ(extract<std::int16_t>(buffer, 0, std::endian::little), -20670);
+    EXPECT_EQ(extract<std::uint16_t>(buffer, 2, std::endian::little), 8426);
+    EXPECT_EQ(extract<std::int16_t>(buffer, 2, std::endian::little), 8426);
+
+    EXPECT_EQ(extract<std::uint16_t>(buffer, 0, std::endian::big), 17071);
+    EXPECT_EQ(extract<std::int16_t>(buffer, 0, std::endian::big), 17071);
+    EXPECT_EQ(extract<std::uint16_t>(buffer, 2, std::endian::big), 59936);
+    EXPECT_EQ(extract<std::int16_t>(buffer, 2, std::endian::big), -5600);
+}
+
+TEST(ParserExtract, Int32)
+{
+    const std::array<std::uint8_t, 8> data = {
+        0xAF, 0x42, 0x00, 0x20, 0x44, 0x7A, 0x77, 0xAE};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<std::uint32_t>(buffer, 0, std::endian::little), 536887983);
+    EXPECT_EQ(extract<std::int32_t>(buffer, 0, std::endian::little), 536887983);
+    EXPECT_EQ(extract<std::uint32_t>(buffer, 4, std::endian::little), 2927065668);
+    EXPECT_EQ(extract<std::int32_t>(buffer, 4, std::endian::little), -1367901628);
+
+    EXPECT_EQ(extract<std::uint32_t>(buffer, 0, std::endian::big), 2940338208);
+    EXPECT_EQ(extract<std::int32_t>(buffer, 0, std::endian::big), -1354629088);
+    EXPECT_EQ(extract<std::uint32_t>(buffer, 4, std::endian::big), 1148876718);
+    EXPECT_EQ(extract<std::int32_t>(buffer, 4, std::endian::big), 1148876718);
+}
+
+TEST(ParserExtract, Int64)
+{
+    const std::array<std::uint8_t, 16> data = {
+        0xAF, 0x42, 0x00, 0xAE, 0x44, 0x7A, 0x77, 0x20,
+        0xE0, 0x5B, 0xC6, 0x70, 0x04, 0x00, 0x00, 0xE0};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<std::uint64_t>(buffer, 0, std::endian::little), 2339472966837879471ULL);
+    EXPECT_EQ(extract<std::int64_t>(buffer, 0, std::endian::little), 2339472966837879471LL);
+    EXPECT_EQ(extract<std::uint64_t>(buffer, 8, std::endian::little), 16140901083567774688ULL);
+    EXPECT_EQ(extract<std::int64_t>(buffer, 8, std::endian::little), -2305842990141776928LL);
+
+    EXPECT_EQ(extract<std::uint64_t>(buffer, 0, std::endian::big), 12628657053573478176ULL);
+    EXPECT_EQ(extract<std::int64_t>(buffer, 0, std::endian::big), -5818087020136073440LL);
+    EXPECT_EQ(extract<std::uint64_t>(buffer, 8, std::endian::big), 16166733471782273248ULL);
+    EXPECT_EQ(extract<std::int64_t>(buffer, 8, std::endian::big), -2280010601927278368LL);
+}
+
+TEST(ParserExtract, Float)
+{
+    const std::array<std::uint8_t, 8> data = {
+        0x10, 0x06, 0x9E, 0xBF, 0xC0, 0xB5, 0xB9, 0x8C};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<float>(buffer, 0, std::endian::little), -1.23456F);
+    EXPECT_EQ(extract<float>(buffer, 4, std::endian::little), -2.861315e-31F);
+
+    EXPECT_EQ(extract<float>(buffer, 0, std::endian::big), 2.6549134e-29F);
+    EXPECT_EQ(extract<float>(buffer, 4, std::endian::big), -5.6788998F);
+}
+
+TEST(ParserExtract, Double)
+{
+    const std::array<std::uint8_t, 16> data = {
+        0x0B, 0x0B, 0xEE, 0x07, 0x3C, 0xDD, 0x5E, 0xC0,
+        0xC0, 0x23, 0xC0, 0xCA, 0x45, 0x88, 0xF6, 0x33};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<double>(buffer, 0, std::endian::little), -123.456789);
+    EXPECT_EQ(extract<double>(buffer, 8, std::endian::little), 2.2435030420065675e-58);
+
+    EXPECT_EQ(extract<double>(buffer, 0, std::endian::big), 1.8601222332385153e-255);
+    EXPECT_EQ(extract<double>(buffer, 8, std::endian::big), -9.8765432099999995);
+}
+
+TEST(ParserExtract, Enum)
+{
+    const std::array<std::uint8_t, 16> data = {
+        0x00, 0x01, 0x01, 0x00};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    EXPECT_EQ(extract<TestEnum>(buffer, 0, std::endian::little), TestEnum::B);
+    EXPECT_EQ(extract<TestEnum>(buffer, 2, std::endian::little), TestEnum::A);
+
+    EXPECT_EQ(extract<TestEnum>(buffer, 0, std::endian::big), TestEnum::A);
+    EXPECT_EQ(extract<TestEnum>(buffer, 2, std::endian::big), TestEnum::B);
+}
+
+TEST(ParserExtract, U8String)
+{
+    const std::array<std::uint8_t, 14> data = {
+        0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0xF0, 0x9F, 0x91, 0xBB, 0x00, 0xFF, 0xFF, 0xFF};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    std::optional<std::size_t> size;
+    EXPECT_EQ(extract_string<char>(buffer, 0, size), "Hello 👻");
+    EXPECT_THAT(size, testing::Optional(std::size_t(10)));
+
+    size = 5;
+    EXPECT_EQ(extract_string<char>(buffer, 0, size), "Hello");
+    EXPECT_THAT(size, testing::Optional(std::size_t(5)));
+
+    size = std::nullopt;
+    EXPECT_EQ(extract_string<char>(buffer, 6, size), "👻");
+    EXPECT_THAT(size, testing::Optional(std::size_t(4)));
+}
+
+TEST(ParserExtract, U16String)
+{
+    const std::array<std::uint8_t, 21> data = {
+        0x48, 0x00, 0x65, 0x00, 0x6C, 0x00, 0x6C, 0x00, 0x6F, 0x00, 0x20, 0x00, 0x3D, 0xD8, 0x7B, 0xDC,
+        0x00, 0x00, 0xFF, 0xFF, 0xFF};
+    const auto buffer = std::as_bytes(std::span(data));
+
+    std::optional<std::size_t> size;
+    EXPECT_EQ(extract_string<char16_t>(buffer, 0, size), std::u16string_view(u"Hello 👻"));
+    EXPECT_THAT(size, testing::Optional(std::size_t(8)));
+
+    EXPECT_EQ(std::bit_cast<char16_t>(std::uint16_t(0x0048)), u'H');
+    size = 5;
+    EXPECT_EQ(extract_string<char16_t>(buffer, 0, size), std::u16string_view(u"Hello"));
+    EXPECT_THAT(size, testing::Optional(std::size_t(5)));
+
+    size = std::nullopt;
+    EXPECT_EQ(extract_string<char16_t>(buffer, 12, size), std::u16string_view(u"👻"));
+    EXPECT_THAT(size, testing::Optional(std::size_t(2)));
+}


### PR DESCRIPTION
Reduce code duplication between ETL and common parsers and adds unit tests.