### PR TITLE
Fix code coverage modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,20 @@ if(BUILD_TESTING)
   add_subdirectory(apps)
 endif()
 
-string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _SOURCE_DIR_REGEX "${PROJECT_SOURCE_DIR}")
+set(coverage_exclude_dirs
+  "tests"
+  "snail/common/third_party"
+)
+
+set(coverage_exclude_regexes)
+foreach(dir IN LISTS coverage_exclude_dirs)
+  cmake_path(APPEND PROJECT_SOURCE_DIR "${dir}" OUTPUT_VARIABLE _exclude_path)
+  cmake_path(NATIVE_PATH _exclude_path NORMALIZE _exclude_path)
+  string(REGEX REPLACE "([][+.*()^\\])" "\\\\\\1" _exclude_path_regex "${_exclude_path}")
+  list(APPEND coverage_exclude_regexes "${_exclude_path_regex}")
+endforeach()
+
+list(JOIN coverage_exclude_regexes "|" coverage_joined_exclude_regex)
 code_coverage_report(
-  EXCLUDE "${_SOURCE_DIR_REGEX}/tests/"
+  EXCLUDE "${coverage_joined_exclude_regex}"
 )

--- a/cmake/modules/CodeCoverage.cmake
+++ b/cmake/modules/CodeCoverage.cmake
@@ -159,9 +159,12 @@ function(code_coverage_report)
     set(_all_objects)
     get_property(_targets GLOBAL PROPERTY "_CodeCoverage_targets")
     foreach(target_name IN LISTS _targets)
-      list(APPEND _all_objects
-        -object "$<TARGET_FILE:${target_name}>"
-      )
+      get_target_property(target_type ${target_name} TYPE)
+      if("${target_type}" STREQUAL "SHARED_LIBRARY" OR "${target_type}" STREQUAL "EXECUTABLE")
+        list(APPEND _all_objects
+          -object "$<TARGET_FILE:${target_name}>"
+        )
+      endif()
     endforeach()
 
     set(_data_dir "${CMAKE_BINARY_DIR}/tests/unit/code_coverage") # TODO: detect these


### PR DESCRIPTION
Fixes passing incorrect targets to `llvm-cov` and improves the the exclusion regex.