### PR TITLE
Fix issues in DWARF resolver

### DIFF
--- a/snail/analysis/detail/dwarf_resolver.cpp
+++ b/snail/analysis/detail/dwarf_resolver.cpp
@@ -28,8 +28,8 @@ const dwarf_resolver::symbol_info& dwarf_resolver::make_generic_symbol(instructi
                                  .load_timestamp = 0},
         .address = address
     };
-    auto iter = symbol_cache.find(key);
-    if(iter != symbol_cache.end()) return iter->second;
+    auto iter = symbol_cache_.find(key);
+    if(iter != symbol_cache_.end()) return iter->second;
 
     const auto new_symbol = symbol_info{
         .name                    = std::format("{:#018x}", address),
@@ -39,7 +39,7 @@ const dwarf_resolver::symbol_info& dwarf_resolver::make_generic_symbol(instructi
         .instruction_line_number = {},
     };
 
-    const auto [new_iter, _] = symbol_cache.emplace(key, new_symbol);
+    const auto [new_iter, _] = symbol_cache_.emplace(key, new_symbol);
     return new_iter->second;
 }
 
@@ -51,8 +51,8 @@ const dwarf_resolver::symbol_info& dwarf_resolver::make_generic_symbol(const mod
                                  .load_timestamp = module.load_timestamp},
         .address = address
     };
-    auto iter = symbol_cache.find(key);
-    if(iter != symbol_cache.end()) return iter->second;
+    auto iter = symbol_cache_.find(key);
+    if(iter != symbol_cache_.end()) return iter->second;
 
     auto delimiter_pos = module.image_filename.find_last_of('\\');
     if(delimiter_pos == std::u16string::npos) delimiter_pos = module.image_filename.find_last_of("//");
@@ -67,7 +67,7 @@ const dwarf_resolver::symbol_info& dwarf_resolver::make_generic_symbol(const mod
         .instruction_line_number = {},
     };
 
-    const auto [new_iter, inserted] = symbol_cache.emplace(key, new_symbol);
+    const auto [new_iter, inserted] = symbol_cache_.emplace(key, new_symbol);
     assert(inserted);
     return new_iter->second;
 }
@@ -90,8 +90,8 @@ const dwarf_resolver::symbol_info& dwarf_resolver::resolve_symbol(const module_i
                                  .load_timestamp = module.load_timestamp},
         .address = address
     };
-    auto iter = symbol_cache.find(key);
-    if(iter != symbol_cache.end()) return iter->second;
+    auto iter = symbol_cache_.find(key);
+    if(iter != symbol_cache_.end()) return iter->second;
 
 #ifdef SNAIL_HAS_LLVM
     const auto relative_address = address - module.image_base + module.page_offset;
@@ -146,7 +146,7 @@ const dwarf_resolver::symbol_info& dwarf_resolver::resolve_symbol(const module_i
         new_symbol.name = line_info.FunctionName;
     }
 
-    const auto [new_iter, inserted] = symbol_cache.emplace(key, std::move(new_symbol));
+    const auto [new_iter, inserted] = symbol_cache_.emplace(key, std::move(new_symbol));
     assert(inserted);
     return new_iter->second;
 #else  // SNAIL_HAS_LLVM
@@ -161,8 +161,8 @@ dwarf_resolver::context_storage* dwarf_resolver::get_dwarf_context(const module_
         .process_id     = module.process_id,
         .load_timestamp = module.load_timestamp};
 
-    auto iter = dwarf_context_cache.find(key);
-    if(iter != dwarf_context_cache.end()) return iter->second.get();
+    auto iter = dwarf_context_cache_.find(key);
+    if(iter != dwarf_context_cache_.end()) return iter->second.get();
 
     const auto* const pmsc   = R"(C:\Users\aziegenhagel\data\pmsc.cpython-311-x86_64-linux-gnu.so)";
     const auto* const python = R"(C:\Users\aziegenhagel\data\libpython3.11.so)";
@@ -198,7 +198,7 @@ dwarf_resolver::context_storage* dwarf_resolver::get_dwarf_context(const module_
         return nullptr;
     }
 
-    auto& storage = dwarf_context_cache[key];
+    auto& storage = dwarf_context_cache_[key];
 
     storage = std::make_unique<context_storage>();
 

--- a/snail/analysis/detail/dwarf_resolver.hpp
+++ b/snail/analysis/detail/dwarf_resolver.hpp
@@ -67,10 +67,10 @@ private:
 
     context_storage* get_dwarf_context(const module_info& module);
 
-    std::unordered_map<module_key, std::unique_ptr<context_storage>, module_key_hasher> dwarf_context_cache;
+    std::unordered_map<module_key, std::unique_ptr<context_storage>, module_key_hasher> dwarf_context_cache_;
 #endif // SNAIL_HAS_LLVM
 
-    std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache;
+    std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache_;
 };
 
 struct dwarf_resolver::symbol_info

--- a/snail/analysis/detail/pdb_resolver.hpp
+++ b/snail/analysis/detail/pdb_resolver.hpp
@@ -75,10 +75,10 @@ private:
 #ifdef SNAIL_HAS_LLVM
     llvm::pdb::IPDBSession* get_pdb_session(const module_info& module);
 
-    std::unordered_map<module_key, std::unique_ptr<llvm::pdb::IPDBSession>, module_key_hasher> pdb_session_cache;
+    std::unordered_map<module_key, std::unique_ptr<llvm::pdb::IPDBSession>, module_key_hasher> pdb_session_cache_;
 #endif // SNAIL_HAS_LLVM
 
-    std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache;
+    std::unordered_map<symbol_key, symbol_info, symbol_key_hasher> symbol_cache_;
 };
 
 struct pdb_resolver::symbol_info


### PR DESCRIPTION
This fixes finding the correct section for the symbol by explicitly handling ELF objects. This allows us to compare the relative address to the offsets of the sections in the binary. Before this change, we tried to compare the relative offset to the address of the section, which includes the default image base offset.

Additionally we make sure that we try to look up a binary for each module only once, and create an empty cache entry in case no binary could be found.