### PR TITLE
Support extracting build-ids from perf-data

### DIFF
--- a/apps/etl_file.cpp
+++ b/apps/etl_file.cpp
@@ -239,7 +239,7 @@ options parse_command_line(int argc, char* argv[]) // NOLINT(modernize-avoid-c-a
         }
         else if(etl_file_path != std::nullopt)
         {
-            print_error_and_exit(application_path, std::format("Multiple files not supported: first was '' second is '{}'", etl_file_path->string(), current_arg));
+            print_error_and_exit(application_path, std::format("Multiple files not supported: first was '{}' second is '{}'", etl_file_path->string(), current_arg));
         }
         else
         {

--- a/apps/etl_file.cpp
+++ b/apps/etl_file.cpp
@@ -1,15 +1,17 @@
 
 #include <snail/etl/etl_file.hpp>
 
+#ifdef _WIN32
+#    define NOMINMAX
+#    define WIN32_LEAN_AND_MEAN
+#    include <Windows.h>
+#endif
+
 #include <optional>
 #include <stdexcept>
 #include <string_view>
 
 #include <utf8/cpp17.h>
-
-#ifdef _WIN32
-#    include <Windows.h>
-#endif
 
 #include <snail/etl/dispatching_event_observer.hpp>
 

--- a/apps/perf_data_file.cpp
+++ b/apps/perf_data_file.cpp
@@ -34,8 +34,7 @@ int main(int /*argc*/, char* /*argv*/[])
     };
 
     observer.register_event<perf_data::parser::id_index_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::id_index_event_view& event)
+        [&](const perf_data::parser::id_index_event_view& event)
         {
             flush_samples();
             std::cout << std::format("ID INDEX; nr {}:", event.nr()) << "\n";
@@ -47,8 +46,7 @@ int main(int /*argc*/, char* /*argv*/[])
             }
         });
     observer.register_event<perf_data::parser::thread_map_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::thread_map_event_view& event)
+        [&](const perf_data::parser::thread_map_event_view& event)
         {
             flush_samples();
             std::cout << std::format("THREAD MAP; nr {}:", event.nr()) << "\n";
@@ -60,8 +58,7 @@ int main(int /*argc*/, char* /*argv*/[])
             }
         });
     observer.register_event<perf_data::parser::cpu_map_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::cpu_map_event_view& event)
+        [&](const perf_data::parser::cpu_map_event_view& event)
         {
             flush_samples();
             switch(event.type())
@@ -97,51 +94,44 @@ int main(int /*argc*/, char* /*argv*/[])
             }
         });
     observer.register_event<perf_data::parser::comm_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::comm_event_view& event)
+        [&](const perf_data::parser::comm_event_view& event)
         {
             flush_samples();
             std::cout << std::format("COMM @{} ({},{}): {}", *event.sample_id().time, event.pid(), event.tid(), event.comm()) << "\n";
         });
     observer.register_event<perf_data::parser::mmap2_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::mmap2_event_view& event)
+        [&](const perf_data::parser::mmap2_event_view& event)
         {
             flush_samples();
             std::cout << std::format("MMAP2 @{} ({},{}): {} @{:#018x} + {:#018x} ; {:#18x}", *event.sample_id().time, event.pid(), event.tid(), event.filename(), event.addr(), event.len(), event.pgoff()) << "\n";
         });
     observer.register_event<perf_data::parser::fork_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::fork_event_view& event)
+        [&](const perf_data::parser::fork_event_view& event)
         {
             flush_samples();
             std::cout << std::format("FORK @{}|{} ({},{}) -> ({},{})", *event.sample_id().time, event.time(), event.ppid(), event.ptid(), event.pid(), event.tid()) << "\n";
         });
     observer.register_event<perf_data::parser::exit_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::exit_event_view& event)
+        [&](const perf_data::parser::exit_event_view& event)
         {
             flush_samples();
             std::cout << std::format("EXIT @{}|{} ({},{}) -> ({},{})", *event.sample_id().time, event.time(), event.ppid(), event.ptid(), event.pid(), event.tid()) << "\n";
         });
     observer.register_event<perf_data::parser::finished_round_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::finished_round_event_view& /*event*/)
+        [&](const perf_data::parser::finished_round_event_view& /*event*/)
         {
             flush_samples();
             std::cout << std::format("FINISHED ROUND") << "\n";
         });
     observer.register_event<perf_data::parser::finished_init_event_view>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::finished_init_event_view& /*event*/)
+        [&](const perf_data::parser::finished_init_event_view& /*event*/)
         {
             flush_samples();
             std::cout << std::format("FINISHED INIT") << "\n";
         });
 
     observer.register_event<perf_data::parser::sample_event>(
-        [&](const perf_data::parser::event_header_view& /*header*/,
-            const perf_data::parser::sample_event& event)
+        [&](const perf_data::parser::sample_event& event)
         {
             ++samples_data.count;
             samples_data.first_time = std::min(samples_data.first_time, *event.time);

--- a/snail/analysis/detail/perf_data_file_process_context.cpp
+++ b/snail/analysis/detail/perf_data_file_process_context.cpp
@@ -68,14 +68,13 @@ template<typename T>
 void perf_data_file_process_context::register_event()
 {
     observer_.register_event<T>(
-        [this](const perf_data::parser::event_header_view& header, const T& event)
+        [this](const T& event)
         {
-            this->handle_event(header, event);
+            this->handle_event(event);
         });
 }
 
-void perf_data_file_process_context::handle_event(const perf_data::parser::event_header_view& /*header*/,
-                                                  const perf_data::parser::comm_event_view& event)
+void perf_data_file_process_context::handle_event(const perf_data::parser::comm_event_view& event)
 {
     const auto pid  = event.pid();
     const auto tid  = event.tid();
@@ -95,8 +94,7 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::event
                                    });
 }
 
-void perf_data_file_process_context::handle_event(const perf_data::parser::event_header_view& /*header*/,
-                                                  const perf_data::parser::fork_event_view& event)
+void perf_data_file_process_context::handle_event(const perf_data::parser::fork_event_view& event)
 {
     const auto pid  = event.pid();
     const auto tid  = event.tid();
@@ -115,8 +113,7 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::event
     threads_per_process_[pid].emplace(tid, time);
 }
 
-void perf_data_file_process_context::handle_event(const perf_data::parser::event_header_view& /*header*/,
-                                                  const perf_data::parser::mmap2_event_view& event)
+void perf_data_file_process_context::handle_event(const perf_data::parser::mmap2_event_view& event)
 {
     auto& process_modules = modules_per_process[event.pid()];
 
@@ -129,8 +126,7 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::event
                            *event.sample_id().time);
 }
 
-void perf_data_file_process_context::handle_event(const perf_data::parser::event_header_view& /*header*/,
-                                                  const perf_data::parser::sample_event& event)
+void perf_data_file_process_context::handle_event(const perf_data::parser::sample_event& event)
 {
     assert(event.pid);
     assert(event.tid);

--- a/snail/analysis/detail/perf_data_file_process_context.hpp
+++ b/snail/analysis/detail/perf_data_file_process_context.hpp
@@ -93,10 +93,10 @@ private:
     template<typename T>
     void register_event();
 
-    void handle_event(const perf_data::parser::event_header_view& header, const perf_data::parser::comm_event_view& event);
-    void handle_event(const perf_data::parser::event_header_view& header, const perf_data::parser::fork_event_view& event);
-    void handle_event(const perf_data::parser::event_header_view& header, const perf_data::parser::mmap2_event_view& event);
-    void handle_event(const perf_data::parser::event_header_view& header, const perf_data::parser::sample_event& event);
+    void handle_event(const perf_data::parser::comm_event_view& event);
+    void handle_event(const perf_data::parser::fork_event_view& event);
+    void handle_event(const perf_data::parser::mmap2_event_view& event);
+    void handle_event(const perf_data::parser::sample_event& event);
 
     perf_data::dispatching_event_observer observer_;
 

--- a/snail/analysis/perf_data_data_provider.cpp
+++ b/snail/analysis/perf_data_data_provider.cpp
@@ -9,7 +9,7 @@
 #include <snail/perf_data/parser/records/kernel.hpp>
 #include <snail/perf_data/perf_data_file.hpp>
 
-#include <snail/perf_data/detail/metadata.hpp>
+#include <snail/perf_data/metadata.hpp>
 
 #include <snail/analysis/detail/dwarf_resolver.hpp>
 #include <snail/analysis/detail/perf_data_file_process_context.hpp>

--- a/snail/jsonrpc/stream/windows/pipe_streambuf.cpp
+++ b/snail/jsonrpc/stream/windows/pipe_streambuf.cpp
@@ -1,9 +1,11 @@
 
 #include <snail/jsonrpc/stream/windows/pipe_streambuf.hpp>
 
-#include <cassert>
-
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+
+#include <cassert>
 
 using namespace snail::jsonrpc;
 

--- a/snail/perf_data/CMakeLists.txt
+++ b/snail/perf_data/CMakeLists.txt
@@ -3,10 +3,11 @@ add_library(perf_data)
 
 target_sources(perf_data
   PRIVATE
+    build_id.cpp
+    metadata.cpp
     perf_data_file.cpp
     dispatching_event_observer.cpp
-    
-    detail/metadata.cpp
+
     detail/attributes_database.cpp
 
     parser/records/kernel.cpp

--- a/snail/perf_data/build_id.cpp
+++ b/snail/perf_data/build_id.cpp
@@ -1,0 +1,18 @@
+#include <snail/perf_data/build_id.hpp>
+
+#include <cstdint>
+#include <format>
+
+using namespace snail::perf_data;
+
+std::string build_id::to_string() const
+{
+    std::string result;
+    result.reserve(size_ * 2);
+
+    for(std::size_t i = 0; i < size_; ++i)
+    {
+        std::format_to(std::back_inserter(result), "{:02x}", std::to_integer<std::uint8_t>(buffer_[i]));
+    }
+    return result;
+}

--- a/snail/perf_data/build_id.hpp
+++ b/snail/perf_data/build_id.hpp
@@ -1,0 +1,27 @@
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string>
+
+namespace snail::perf_data {
+
+struct build_id
+{
+    static constexpr std::size_t max_size = 20;
+
+    std::size_t                     size_;
+    std::array<std::byte, max_size> buffer_;
+
+    std::string to_string() const;
+
+    [[nodiscard]] friend bool operator==(const build_id& lhs, const build_id& rhs)
+    {
+        return lhs.size_ == rhs.size_ &&
+               std::equal(lhs.buffer_.begin(), lhs.buffer_.begin() + lhs.size_, rhs.buffer_.begin());
+    }
+};
+
+} // namespace snail::perf_data

--- a/snail/perf_data/dispatching_event_observer.cpp
+++ b/snail/perf_data/dispatching_event_observer.cpp
@@ -16,6 +16,6 @@ void dispatching_event_observer::handle(const parser::event_header_view& event_h
 
     for(const auto& handler : iter->second)
     {
-        handler(event_header, attributes, event_data, byte_order);
+        handler(attributes, event_data, byte_order);
     }
 }

--- a/snail/perf_data/metadata.cpp
+++ b/snail/perf_data/metadata.cpp
@@ -1,11 +1,11 @@
 
-#include <snail/perf_data/detail/metadata.hpp>
+#include <snail/perf_data/metadata.hpp>
 
 #include <snail/perf_data/detail/attributes_database.hpp>
 
-using namespace snail::perf_data::detail;
+using namespace snail::perf_data;
 
-void perf_data_metadata::extract_event_attributes_database(event_attributes_database& database)
+void perf_data_metadata::extract_event_attributes_database(detail::event_attributes_database& database)
 {
     database.all_attributes.clear();
     database.id_to_attributes.clear();

--- a/snail/perf_data/metadata.hpp
+++ b/snail/perf_data/metadata.hpp
@@ -5,17 +5,25 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <snail/perf_data/parser/event_attributes.hpp>
 
-namespace snail::perf_data::detail {
+#include <snail/perf_data/build_id.hpp>
+
+namespace snail::perf_data {
+
+namespace detail {
 
 struct event_attributes_database;
 
+} // namespace detail
+
 struct perf_data_metadata
 {
-    // build_id_event build_id;
+    std::optional<std::unordered_map<std::string, build_id>> build_ids;
+
     std::optional<std::string> hostname;
     std::optional<std::string> os_release;
     std::optional<std::string> version;
@@ -62,7 +70,7 @@ struct perf_data_metadata
     // hybrid_topology;
     // pmu_caps;
 
-    void extract_event_attributes_database(event_attributes_database& database);
+    void extract_event_attributes_database(detail::event_attributes_database& database);
 };
 
-} // namespace snail::perf_data::detail
+} // namespace snail::perf_data

--- a/snail/perf_data/parser/event.hpp
+++ b/snail/perf_data/parser/event.hpp
@@ -65,6 +65,31 @@ enum class event_type : std::uint32_t
     // Perf events
 };
 
+enum class header_misc_mask : std::uint16_t
+{
+    // the first three bytes are a cpu mode mask
+    cpumode_mask    = 0b111,
+    cpumode_unknown = 0b000,
+    kernel          = 0b001,
+    user            = 0b010,
+    hypervisor      = 0b011,
+    guest_kernel    = 0b100,
+    guest_user      = 0b101,
+
+    proc_map_parse_timeout = (1 << 12),
+
+    mmap_data  = (1 << 13), // on mmap events
+    comm_exec  = (1 << 13), // on comm events
+    fork_exec  = (1 << 13), // on fork events
+    switch_out = (1 << 13), // on switch events
+
+    exact_ip           = (1 << 14), // on sample events
+    switch_out_preempt = (1 << 14), // on switch events
+    mmap_build_id      = (1 << 14), // on mmap events
+
+    ext_reserved = (1 << 15),
+};
+
 struct event_header_view : protected common::parser::extract_view_base
 {
     using extract_view_base::extract_view_base;
@@ -73,15 +98,38 @@ struct event_header_view : protected common::parser::extract_view_base
     inline auto misc() const { return extract<std::uint16_t>(4); }
     inline auto size() const { return extract<std::uint16_t>(6); }
 
+    using extract_view_base::buffer;
+
     static inline constexpr std::size_t static_size = 8;
 };
 
 struct event_view_base : protected common::parser::extract_view_base
 {
-    inline explicit event_view_base(const event_attributes& attributes, std::span<const std::byte> buffer, std::endian byte_order) :
-        extract_view_base(buffer, byte_order),
+    inline explicit event_view_base(std::span<const std::byte> buffer, std::endian byte_order) :
+        extract_view_base(buffer.subspan(event_header_view::static_size), byte_order),
+        header_view_(buffer.subspan(0, event_header_view::static_size), byte_order)
+    {}
+
+    event_header_view header() const
+    {
+        return header_view_;
+    }
+
+    using extract_view_base::buffer;
+
+private:
+    event_header_view header_view_;
+};
+
+struct attribute_event_view_base : protected event_view_base
+{
+    inline explicit attribute_event_view_base(const event_attributes& attributes, std::span<const std::byte> buffer, std::endian byte_order) :
+        event_view_base(buffer, byte_order),
         attributes_(&attributes)
     {}
+
+    using event_view_base::buffer;
+    using event_view_base::header;
 
 protected:
     const event_attributes& attributes() const

--- a/snail/perf_data/parser/event_attributes.hpp
+++ b/snail/perf_data/parser/event_attributes.hpp
@@ -210,7 +210,9 @@ struct event_attributes_view : protected common::parser::extract_view_base
 
     inline auto sig_data() const { return extract<std::uint64_t>(120); }
 
-    static inline constexpr std::size_t static_size = 128;
+    inline auto config3() const { return extract<std::uint64_t>(128); }
+
+    static inline constexpr std::size_t static_size = 134;
 
     inline auto instantiate() const
     {

--- a/snail/perf_data/parser/records/kernel.cpp
+++ b/snail/perf_data/parser/records/kernel.cpp
@@ -51,7 +51,7 @@ sample_event snail::perf_data::parser::parse_event(const event_attributes&    at
 {
     sample_event result;
 
-    std::size_t offset = 0;
+    std::size_t offset = event_header_view::static_size;
 
     result.id        = extract_move_if<std::uint64_t>(attributes.sample_format.test(parser::sample_format::identifier), buffer, offset, byte_order);
     result.ip        = extract_move_if<std::uint64_t>(attributes.sample_format.test(parser::sample_format::ip), buffer, offset, byte_order);

--- a/snail/perf_data/perf_data_file.hpp
+++ b/snail/perf_data/perf_data_file.hpp
@@ -18,9 +18,10 @@ struct event_attributes;
 namespace detail {
 
 struct perf_data_file_header_data;
-struct perf_data_metadata;
 
 } // namespace detail
+
+struct perf_data_metadata;
 
 class event_observer;
 
@@ -38,13 +39,13 @@ public:
 
     void process(event_observer& callbacks);
 
-    const detail::perf_data_metadata& metadata() const;
+    const perf_data_metadata& metadata() const;
 
 private:
     std::ifstream file_stream_;
 
     std::unique_ptr<detail::perf_data_file_header_data> header_;
-    std::unique_ptr<detail::perf_data_metadata>         metadata_;
+    std::unique_ptr<perf_data_metadata>                 metadata_;
 };
 
 class event_observer

--- a/snail/server/main.cpp
+++ b/snail/server/main.cpp
@@ -8,6 +8,8 @@
 #include <string>
 
 #if defined(_WIN32)
+#    define NOMINMAX
+#    define WIN32_LEAN_AND_MEAN
 #    include <Windows.h>
 #endif
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -63,6 +63,7 @@ add_unit_test_executable(perf_data
   SOURCES
     perf_data/parser.cpp
     perf_data/event_observer.cpp
+    perf_data/utility.cpp
   DEPENDENCIES
     perf_data
 )

--- a/tests/unit/jsonrpc/pipe.cpp
+++ b/tests/unit/jsonrpc/pipe.cpp
@@ -1,10 +1,13 @@
+
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
 #include <gtest/gtest.h>
 
 #include <snail/jsonrpc/stream/windows/pipe_iostream.hpp>
 
 #include <fstream>
-
-#include <Windows.h>
 
 using namespace snail::jsonrpc;
 

--- a/tests/unit/perf_data/event_observer.cpp
+++ b/tests/unit/perf_data/event_observer.cpp
@@ -35,8 +35,7 @@ TEST(PerfDataDispatchEventObserver, Dispatch)
 
     bool fork_event_called = false;
     observer.register_event<perf_data::parser::fork_event_view>(
-        [&fork_event_called](const perf_data::parser::event_header_view& /*header*/,
-                             const perf_data::parser::fork_event_view& event)
+        [&fork_event_called](const perf_data::parser::fork_event_view& event)
         {
             EXPECT_EQ(event.pid(), 1343);
             EXPECT_EQ(event.ppid(), 1342);
@@ -45,8 +44,7 @@ TEST(PerfDataDispatchEventObserver, Dispatch)
         });
     bool sample_event_called = false;
     observer.register_event<perf_data::parser::sample_event>(
-        [&sample_event_called](const perf_data::parser::event_header_view& /*header*/,
-                               const perf_data::parser::sample_event& event)
+        [&sample_event_called](const perf_data::parser::sample_event& event)
         {
             EXPECT_EQ(event.ip, 140270571258003UL);
             EXPECT_EQ(event.ips, (std::vector<std::uint64_t>{18446744073709551104UL, 140270571258003UL, 94208011558848UL}));
@@ -60,9 +58,8 @@ TEST(PerfDataDispatchEventObserver, Dispatch)
 
         const auto buffer       = std::as_bytes(std::span(fork_buffer_data));
         const auto event_header = perf_data::parser::event_header_view(buffer, std::endian::little);
-        const auto event_buffer = buffer.subspan(perf_data::parser::event_header_view::static_size);
 
-        observer.handle(event_header, event_attributes, event_buffer, std::endian::little);
+        observer.handle(event_header, event_attributes, buffer, std::endian::little);
 
         EXPECT_TRUE(fork_event_called);
         EXPECT_FALSE(sample_event_called);
@@ -74,9 +71,8 @@ TEST(PerfDataDispatchEventObserver, Dispatch)
 
         const auto buffer       = std::as_bytes(std::span(sample_buffer_data));
         const auto event_header = perf_data::parser::event_header_view(buffer, std::endian::little);
-        const auto event_buffer = buffer.subspan(perf_data::parser::event_header_view::static_size);
 
-        observer.handle(event_header, event_attributes, event_buffer, std::endian::little);
+        observer.handle(event_header, event_attributes, buffer, std::endian::little);
 
         EXPECT_FALSE(fork_event_called);
         EXPECT_TRUE(sample_event_called);

--- a/tests/unit/perf_data/parser.cpp
+++ b/tests/unit/perf_data/parser.cpp
@@ -1,6 +1,7 @@
 
 #include <array>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <snail/perf_data/parser/event_attributes.hpp>
@@ -84,7 +85,8 @@ TEST(PerfDataParser, EventAttributes)
 
 TEST(PerfDataParser, KernelCommEvent)
 {
-    const std::array<std::uint8_t, 40> buffer = {
+    const std::array<std::uint8_t, 48> buffer = {
+        0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00,
         0x3e, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x70, 0x65, 0x72, 0x66, 0x2d, 0x65, 0x78, 0x65,
         0x63, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
@@ -100,14 +102,28 @@ TEST(PerfDataParser, KernelCommEvent)
 
     const auto event_view = perf_data::parser::comm_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
 
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::comm_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 40);
+
     EXPECT_EQ(event_view.pid(), 1342);
     EXPECT_EQ(event_view.tid(), 1342);
     EXPECT_EQ(event_view.comm(), "perf-exec");
+
+    const auto sample_id = event_view.sample_id();
+    EXPECT_THAT(sample_id.pid, testing::Optional(0));
+    EXPECT_THAT(sample_id.tid, testing::Optional(0));
+    EXPECT_THAT(sample_id.time, testing::Optional(0));
+    EXPECT_EQ(sample_id.id, std::nullopt);
+    EXPECT_EQ(sample_id.stream_id, std::nullopt);
+    EXPECT_EQ(sample_id.cpu, std::nullopt);
+    EXPECT_EQ(sample_id.res, std::nullopt);
 }
 
 TEST(PerfDataParser, KernelExitEvent)
 {
-    const std::array<std::uint8_t, 40> buffer = {
+    const std::array<std::uint8_t, 48> buffer = {
+        0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00,
         0x3e, 0x05, 0x00, 0x00, 0x3d, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x3d, 0x05, 0x00, 0x00,
         0x08, 0xe7, 0xa0, 0x13, 0xc4, 0x01, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00,
         0x90, 0xe1, 0xa0, 0x13, 0xc4, 0x01, 0x00, 0x00};
@@ -123,16 +139,30 @@ TEST(PerfDataParser, KernelExitEvent)
 
     const auto event_view = perf_data::parser::exit_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
 
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::exit_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 40);
+
     EXPECT_EQ(event_view.pid(), 1342);
     EXPECT_EQ(event_view.ppid(), 1341);
     EXPECT_EQ(event_view.tid(), 1342);
     EXPECT_EQ(event_view.ptid(), 1341);
     EXPECT_EQ(event_view.time(), 1941654529800);
+
+    const auto sample_id = event_view.sample_id();
+    EXPECT_THAT(sample_id.pid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.tid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.time, testing::Optional(1941654528400));
+    EXPECT_EQ(sample_id.id, std::nullopt);
+    EXPECT_EQ(sample_id.stream_id, std::nullopt);
+    EXPECT_EQ(sample_id.cpu, std::nullopt);
+    EXPECT_EQ(sample_id.res, std::nullopt);
 }
 
 TEST(PerfDataParser, KernelForkEvent)
 {
-    const std::array<std::uint8_t, 40> buffer = {
+    const std::array<std::uint8_t, 48> buffer = {
+        0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00,
         0x3f, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x3f, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00,
         0xec, 0xf7, 0xab, 0x37, 0xc3, 0x01, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00,
         0x88, 0xf7, 0xab, 0x37, 0xc3, 0x01, 0x00, 0x00};
@@ -148,16 +178,30 @@ TEST(PerfDataParser, KernelForkEvent)
 
     const auto event_view = perf_data::parser::fork_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
 
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::fork_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 40);
+
     EXPECT_EQ(event_view.pid(), 1343);
     EXPECT_EQ(event_view.ppid(), 1342);
     EXPECT_EQ(event_view.tid(), 1343);
     EXPECT_EQ(event_view.ptid(), 1342);
     EXPECT_EQ(event_view.time(), 1937964267500);
+
+    const auto sample_id = event_view.sample_id();
+    EXPECT_THAT(sample_id.pid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.tid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.time, testing::Optional(1937964267400));
+    EXPECT_EQ(sample_id.id, std::nullopt);
+    EXPECT_EQ(sample_id.stream_id, std::nullopt);
+    EXPECT_EQ(sample_id.cpu, std::nullopt);
+    EXPECT_EQ(sample_id.res, std::nullopt);
 }
 
 TEST(PerfDataParser, KernelMmap2Event)
 {
-    const std::array<std::uint8_t, 128> buffer = {
+    const std::array<std::uint8_t, 136> buffer = {
+        0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00,
         0x3e, 0x05, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x00, 0x50, 0x0e, 0xce, 0x94, 0x7f, 0x00, 0x00,
         0x00, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x08, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x6e, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -178,6 +222,10 @@ TEST(PerfDataParser, KernelMmap2Event)
 
     const auto event_view = perf_data::parser::mmap2_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
 
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::mmap2_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 128);
+
     EXPECT_EQ(event_view.pid(), 1342);
     EXPECT_EQ(event_view.tid(), 1342);
 
@@ -185,14 +233,30 @@ TEST(PerfDataParser, KernelMmap2Event)
     EXPECT_EQ(event_view.len(), 20480);
     EXPECT_EQ(event_view.pgoff(), 8192);
 
+    EXPECT_FALSE(event_view.has_build_id());
+    EXPECT_EQ(event_view.maj(), 8);
+    EXPECT_EQ(event_view.min(), 32);
+    EXPECT_EQ(event_view.ino(), 24942);
+    EXPECT_EQ(event_view.ino_generation(), 242810420);
+
     EXPECT_EQ(event_view.prot(), 5);
     EXPECT_EQ(event_view.flags(), 2);
     EXPECT_EQ(event_view.filename(), "/usr/lib64/openmpi/lib/openmpi/mca_btl_vader.so");
+
+    const auto sample_id = event_view.sample_id();
+    EXPECT_THAT(sample_id.pid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.tid, testing::Optional(1342));
+    EXPECT_THAT(sample_id.time, testing::Optional(1938327778300));
+    EXPECT_EQ(sample_id.id, std::nullopt);
+    EXPECT_EQ(sample_id.stream_id, std::nullopt);
+    EXPECT_EQ(sample_id.cpu, std::nullopt);
+    EXPECT_EQ(sample_id.res, std::nullopt);
 }
 
 TEST(PerfDataParser, KernelSampleEvent)
 {
-    const std::array<std::uint8_t, 64> buffer = {
+    const std::array<std::uint8_t, 72> buffer = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x93, 0x80, 0x92, 0x49, 0x93, 0x7f, 0x00, 0x00, 0x3f, 0x05, 0x00, 0x00, 0x3f, 0x05, 0x00, 0x00,
         0x38, 0xb7, 0xf5, 0x37, 0xc3, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -225,7 +289,8 @@ TEST(PerfDataParser, KernelSampleEvent)
 
 TEST(PerfDataParser, PerfIdIndexEvent)
 {
-    const std::array<std::uint8_t, 264> buffer = {
+    const std::array<std::uint8_t, 272> buffer = {
+        0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x01,
         0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xcd, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x3e, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xce, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -244,16 +309,11 @@ TEST(PerfDataParser, PerfIdIndexEvent)
         0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x3e, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-    const auto attributes = perf_data::parser::event_attributes{
-        // in the following, only sample_format is used.
-        .type          = {},
-        .sample_format = perf_data::parser::sample_format_flags(295),
-        .read_format   = {},
-        .flags         = {},
-        .precise_ip    = {},
-        .name          = {}};
+    const auto event_view = perf_data::parser::id_index_event_view(std::as_bytes(std::span(buffer)), std::endian::little);
 
-    const auto event_view = perf_data::parser::id_index_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::id_index_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 264);
 
     EXPECT_EQ(event_view.nr(), 8);
     EXPECT_EQ(event_view.entry(0).id(), 461);
@@ -264,48 +324,85 @@ TEST(PerfDataParser, PerfIdIndexEvent)
     EXPECT_EQ(event_view.entry(1).idx(), 1);
     EXPECT_EQ(event_view.entry(1).cpu(), 1);
     EXPECT_EQ(event_view.entry(1).tid(), 1342);
+    EXPECT_EQ(event_view.entry(2).id(), 463);
+    EXPECT_EQ(event_view.entry(2).idx(), 2);
+    EXPECT_EQ(event_view.entry(2).cpu(), 2);
+    EXPECT_EQ(event_view.entry(2).tid(), 1342);
+    EXPECT_EQ(event_view.entry(3).id(), 464);
+    EXPECT_EQ(event_view.entry(3).idx(), 3);
+    EXPECT_EQ(event_view.entry(3).cpu(), 3);
+    EXPECT_EQ(event_view.entry(3).tid(), 1342);
+    EXPECT_EQ(event_view.entry(4).id(), 465);
+    EXPECT_EQ(event_view.entry(4).idx(), 4);
+    EXPECT_EQ(event_view.entry(4).cpu(), 4);
+    EXPECT_EQ(event_view.entry(4).tid(), 1342);
+    EXPECT_EQ(event_view.entry(5).id(), 466);
+    EXPECT_EQ(event_view.entry(5).idx(), 5);
+    EXPECT_EQ(event_view.entry(5).cpu(), 5);
+    EXPECT_EQ(event_view.entry(5).tid(), 1342);
+    EXPECT_EQ(event_view.entry(6).id(), 467);
+    EXPECT_EQ(event_view.entry(6).idx(), 6);
+    EXPECT_EQ(event_view.entry(6).cpu(), 6);
+    EXPECT_EQ(event_view.entry(6).tid(), 1342);
+    EXPECT_EQ(event_view.entry(7).id(), 468);
+    EXPECT_EQ(event_view.entry(7).idx(), 7);
+    EXPECT_EQ(event_view.entry(7).cpu(), 7);
+    EXPECT_EQ(event_view.entry(7).tid(), 1342);
 }
 
 TEST(PerfDataParser, PerfThreadMapEvent)
 {
-    const std::array<std::uint8_t, 32> buffer = {
+    const std::array<std::uint8_t, 40> buffer = {
+        0x49, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00,
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-    const auto attributes = perf_data::parser::event_attributes{
-        // in the following, only sample_format is used.
-        .type          = {},
-        .sample_format = perf_data::parser::sample_format_flags(295),
-        .read_format   = {},
-        .flags         = {},
-        .precise_ip    = {},
-        .name          = {}};
+    const auto event_view = perf_data::parser::thread_map_event_view(std::as_bytes(std::span(buffer)), std::endian::little);
 
-    const auto event_view = perf_data::parser::thread_map_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::thread_map_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 32);
 
     EXPECT_EQ(event_view.nr(), 1);
     EXPECT_EQ(event_view.entry(0).pid(), 1342);
-    // EXPECT_EQ(event_view.entry(0).comm(), "");
 }
 
 TEST(PerfDataParser, PerfCpuMapEvent)
 {
-    const std::array<std::uint8_t, 32> buffer = {
+    const std::array<std::uint8_t, 40> buffer = {
+        0x4a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00,
         0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3e, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-    const auto attributes = perf_data::parser::event_attributes{
-        // in the following, only sample_format is used.
-        .type          = {},
-        .sample_format = perf_data::parser::sample_format_flags(295),
-        .read_format   = {},
-        .flags         = {},
-        .precise_ip    = {},
-        .name          = {}};
+    const auto event_view = perf_data::parser::cpu_map_event_view(std::as_bytes(std::span(buffer)), std::endian::little);
 
-    const auto event_view = perf_data::parser::cpu_map_event_view(attributes, std::as_bytes(std::span(buffer)), std::endian::little);
+    EXPECT_EQ(event_view.header().type(), perf_data::parser::cpu_map_event_view::event_type);
+    EXPECT_EQ(event_view.header().misc(), 0);
+    EXPECT_EQ(event_view.header().size(), 32);
 
     EXPECT_EQ(event_view.type(), perf_data::parser::cpu_map_type::mask);
     EXPECT_EQ(event_view.mask_data().nr(), 0);
     EXPECT_EQ(event_view.mask_data().long_size(), 0);
+}
+
+TEST(PerfDataParser, PerfHeaderBuildIdEvent)
+{
+    const std::array<std::uint8_t, 100> buffer = {
+        0x00, 0x00, 0x00, 0x00, 0x02, 0x80, 0x64, 0x00, 0xff, 0xff, 0xff, 0xff, 0xeb, 0xc2, 0x58, 0x8d,
+        0xf8, 0x7c, 0xb9, 0x5d, 0x0f, 0x91, 0x29, 0x20, 0x3b, 0xeb, 0xe6, 0x46, 0xed, 0xcd, 0x79, 0x30,
+        0x14, 0x00, 0x00, 0x00, 0x2f, 0x74, 0x6d, 0x70, 0x2f, 0x62, 0x75, 0x69, 0x6c, 0x64, 0x2f, 0x69,
+        0x6e, 0x6e, 0x65, 0x72, 0x2f, 0x44, 0x65, 0x62, 0x75, 0x67, 0x2f, 0x62, 0x75, 0x69, 0x6c, 0x64,
+        0x2f, 0x69, 0x6e, 0x6e, 0x65, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00};
+
+    const auto event_view = perf_data::parser::header_build_id_event_view(std::as_bytes(std::span(buffer)), std::endian::little);
+
+    EXPECT_EQ((int)event_view.header().type(), 0);
+    EXPECT_EQ(event_view.header().misc(), 32770);
+    EXPECT_EQ(event_view.header().size(), 100);
+
+    EXPECT_EQ(event_view.pid(), 0xffffffff);
+    EXPECT_EQ(event_view.build_id().size(), 20);
+    EXPECT_EQ(event_view.filename(), "/tmp/build/inner/Debug/build/inner");
 }

--- a/tests/unit/perf_data/utility.cpp
+++ b/tests/unit/perf_data/utility.cpp
@@ -1,0 +1,59 @@
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include <snail/perf_data/build_id.hpp>
+
+using namespace snail::perf_data;
+
+TEST(BuildId, ToString)
+{
+    const auto id_md5 = build_id{
+        .size_   = 16,
+        .buffer_ = {
+                    std::byte(0xe7), std::byte(0x01), std::byte(0x5f), std::byte(0x7b), std::byte(0x44), std::byte(0x24), std::byte(0x26), std::byte(0x13), std::byte(0xd3), std::byte(0xad),
+                    std::byte(0x95), std::byte(0xc2), std::byte(0xe1), std::byte(0x29), std::byte(0x8c), std::byte(0x41), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF)}
+    };
+    EXPECT_EQ(id_md5.to_string(), "e7015f7b44242613d3ad95c2e1298c41");
+
+    const auto id_sha1 = build_id{
+        .size_   = 20,
+        .buffer_ = {
+                    std::byte(0xef), std::byte(0xdd), std::byte(0x0b), std::byte(0x5e), std::byte(0x69), std::byte(0xb0), std::byte(0x74), std::byte(0x2f), std::byte(0xa5), std::byte(0xe5),
+                    std::byte(0xba), std::byte(0xd0), std::byte(0x77), std::byte(0x1d), std::byte(0xf4), std::byte(0xd1), std::byte(0xdf), std::byte(0x24), std::byte(0x59), std::byte(0xd1)}
+    };
+    EXPECT_EQ(id_sha1.to_string(), "efdd0b5e69b0742fa5e5bad0771df4d1df2459d1");
+}
+
+TEST(BuildId, Compare)
+{
+    const auto id_md5_a = build_id{
+        .size_   = 16,
+        .buffer_ = {
+                    std::byte(0xe7), std::byte(0x01), std::byte(0x5f), std::byte(0x7b), std::byte(0x44), std::byte(0x24), std::byte(0x26), std::byte(0x13), std::byte(0xd3), std::byte(0xad),
+                    std::byte(0x95), std::byte(0xc2), std::byte(0xe1), std::byte(0x29), std::byte(0x8c), std::byte(0x41), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF)}
+    };
+    const auto id_md5_b = build_id{
+        .size_   = 16,
+        .buffer_ = {
+                    std::byte(0xe7), std::byte(0x01), std::byte(0x5f), std::byte(0x7b), std::byte(0x44), std::byte(0x24), std::byte(0x26), std::byte(0x13), std::byte(0xd3), std::byte(0xad),
+                    std::byte(0x95), std::byte(0xc2), std::byte(0xe1), std::byte(0x29), std::byte(0x8c), std::byte(0x41), std::byte(0x00), std::byte(0x00), std::byte(0x00), std::byte(0x00)}
+    };
+    const auto id_md5_c = build_id{
+        .size_   = 16,
+        .buffer_ = {
+                    std::byte(0x95), std::byte(0xc2), std::byte(0xe1), std::byte(0x7b), std::byte(0x44), std::byte(0x24), std::byte(0x26), std::byte(0x13), std::byte(0xd3), std::byte(0xad),
+                    std::byte(0x7b), std::byte(0xe7), std::byte(0x01), std::byte(0x29), std::byte(0x8c), std::byte(0x41), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF), std::byte(0xFF)}
+    };
+
+    EXPECT_TRUE(id_md5_a == id_md5_a);
+    EXPECT_TRUE(id_md5_a == id_md5_b);
+    EXPECT_FALSE(id_md5_a == id_md5_c);
+    EXPECT_FALSE(id_md5_b == id_md5_c);
+
+    EXPECT_FALSE(id_md5_a != id_md5_a);
+    EXPECT_FALSE(id_md5_a != id_md5_b);
+    EXPECT_TRUE(id_md5_a != id_md5_c);
+    EXPECT_TRUE(id_md5_b != id_md5_c);
+}


### PR DESCRIPTION
This comes with two bigger refactoring of event records:

- The buffer passed to the events does now always include the event header. This way, an event is always bundled with its header and can retrieve data from it. This is necessary to extract information from the `misc` header field to determine whether an event actually includes a build id or not.

- Most events can now be created without passing event attributes to it. Only kernel events require the attributes so that the sample_id can be extracted correctly. Since perf events do not have a sample_id they do not require the attributes. This distinction made it easier to implement the `header_build_id` event, that is not read from the regular data section of the perf file, but from the meta-data section where  the event attributes might not be available (this could be changed, but I hope the new design is better. Time will tell whether I am right...).