### PR TITLE
Support downloading symbol information from `debuginfod`

### DIFF
--- a/snail/analysis/CMakeLists.txt
+++ b/snail/analysis/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(analysis
 
     detail/download.cpp
 
+    options.cpp
     path_map.cpp
 
     data_provider.cpp

--- a/snail/analysis/detail/dwarf_resolver.hpp
+++ b/snail/analysis/detail/dwarf_resolver.hpp
@@ -3,8 +3,14 @@
 #include <cstdint>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
+
+#include <snail/perf_data/build_id.hpp>
+
+#include <snail/analysis/options.hpp>
+#include <snail/analysis/path_map.hpp>
 
 namespace snail::analysis::detail {
 
@@ -15,7 +21,7 @@ public:
     using timestamp_t           = std::uint64_t;
     using instruction_pointer_t = std::uint64_t;
 
-    dwarf_resolver();
+    dwarf_resolver(dwarf_symbol_find_options find_options = {}, path_map module_path_map = {});
     ~dwarf_resolver();
 
     struct symbol_info;
@@ -62,6 +68,9 @@ private:
         std::hash<instruction_pointer_t>  address_hasher;
     };
 
+    dwarf_symbol_find_options find_options_;
+    path_map                  module_path_map_;
+
 #ifdef SNAIL_HAS_LLVM
     struct context_storage;
 
@@ -86,7 +95,9 @@ struct dwarf_resolver::symbol_info
 
 struct dwarf_resolver::module_info
 {
-    std::string_view      image_filename;
+    std::string_view                   image_filename;
+    std::optional<perf_data::build_id> build_id;
+
     instruction_pointer_t image_base;
     instruction_pointer_t page_offset;
 

--- a/snail/analysis/options.cpp
+++ b/snail/analysis/options.cpp
@@ -1,0 +1,46 @@
+#include <snail/analysis/options.hpp>
+
+#include <ranges>
+
+#include <snail/common/system.hpp>
+
+using namespace snail::analysis;
+
+dwarf_symbol_find_options::dwarf_symbol_find_options()
+{
+    const auto cache_path_env = common::get_env_var("DEBUGINFOD_CACHE_PATH");
+    if(cache_path_env)
+    {
+        debuginfod_cache_dir_ = *cache_path_env;
+    }
+    else
+    {
+        const auto xdg_cache_home_env = common::get_env_var("XDG_CACHE_HOME");
+        if(xdg_cache_home_env)
+        {
+            debuginfod_cache_dir_ = std::filesystem::path(*cache_path_env) / "snail";
+        }
+        else
+        {
+#ifdef _WIN32
+            // On Windows, we don't want to clutter $HOME with a .cache directory by default.
+            // Hence we put the symbols into the temp directory by default.
+            debuginfod_cache_dir_ = common::get_temp_dir() / "SnailCache";
+#else
+            // On Linux, default is "$HOME/.cache/snail" and fall-back to
+            // "$TEMP/.cache/snail" if we could not determine a valid home directory.
+            const auto home_dir   = common::get_home_dir();
+            debuginfod_cache_dir_ = (home_dir ? *home_dir : common::get_temp_dir()) / ".cache" / "snail";
+#endif
+        }
+    }
+
+    const auto urls_env = common::get_env_var("DEBUGINFOD_URLS");
+    if(urls_env)
+    {
+        for(const auto url : std::views::split(*urls_env, ' '))
+        {
+            debuginfod_urls_.push_back(std::string(std::string_view(url)));
+        }
+    }
+}

--- a/snail/analysis/options.hpp
+++ b/snail/analysis/options.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace snail::analysis {
+
+struct dwarf_symbol_find_options
+{
+    dwarf_symbol_find_options();
+
+    std::vector<std::filesystem::path> search_dirs_;
+
+    std::filesystem::path    debuginfod_cache_dir_;
+    std::vector<std::string> debuginfod_urls_;
+};
+
+} // namespace snail::analysis

--- a/snail/analysis/perf_data_data_provider.cpp
+++ b/snail/analysis/perf_data_data_provider.cpp
@@ -44,6 +44,7 @@ struct perf_data_sample_data : public sample_data
                                      resolver->make_generic_symbol(instruction_pointer) :
                                      resolver->resolve_symbol(detail::dwarf_resolver::module_info{
                                                                   .image_filename = module->payload.filename,
+                                                                  .build_id       = {},
                                                                   .image_base     = module->base,
                                                                   .page_offset    = module->payload.page_offset,
                                                                   .process_id     = process_id,

--- a/snail/common/CMakeLists.txt
+++ b/snail/common/CMakeLists.txt
@@ -3,15 +3,18 @@ add_library(common)
 
 target_sources(common
   PRIVATE
-    trim.cpp
     filename.cpp
     string_compare.cpp
     guid.cpp
+    system.cpp
+    trim.cpp
 )
 
 target_link_libraries(common 
   PRIVATE
     compile_options
+
+    utf8cpp
 )
 
 target_include_directories(common PUBLIC ${CMAKE_SOURCE_DIR})

--- a/snail/common/system.cpp
+++ b/snail/common/system.cpp
@@ -1,0 +1,68 @@
+
+#include <snail/common/system.hpp>
+
+#ifdef _WIN32
+#    include <ShlObj.h>
+#    include <stdlib.h>
+#else
+#    include <cstdlib>
+#endif
+
+#include <utf8/cpp17.h>
+
+using namespace snail::common;
+
+std::filesystem::path snail::common::get_temp_dir() noexcept
+{
+    std::error_code ec;
+
+    auto result = std::filesystem::temp_directory_path(ec);
+    if(!ec)
+    {
+        return result;
+    }
+
+    // Make sure we always return _some_ path...
+#ifdef _WIN32
+    return "C:\\TEMP";
+#else
+    return "/tmp";
+#endif
+}
+
+std::optional<std::filesystem::path> snail::common::get_home_dir() noexcept
+{
+#ifdef _WIN32
+    PWSTR      buffer = nullptr;
+    const auto result = SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &buffer);
+
+    std::unique_ptr<wchar_t, decltype(CoTaskMemFree)*> buffer_ptr(buffer, CoTaskMemFree);
+    if(result != S_OK) return std::nullopt;
+    return std::filesystem::path(buffer_ptr.get());
+#else
+    const auto* const path = std::getenv("HOME");
+    if(path == nullptr) return std::nullopt;
+    return path;
+#endif
+}
+
+std::optional<std::string> snail::common::get_env_var(const std::string& name) noexcept
+{
+#ifdef _WIN32
+    static_assert(sizeof(wchar_t) == sizeof(char16_t));
+
+    const auto  name_u16   = utf8::utf8to16(name);
+    wchar_t*    buffer     = nullptr;
+    std::size_t result_len = 0;
+    if(_wdupenv_s(&buffer, &result_len, reinterpret_cast<const wchar_t*>(name_u16.data())) != 0 || buffer == nullptr)
+    {
+        return std::nullopt;
+    }
+    std::unique_ptr<wchar_t, decltype(free)*> buffer_ptr(buffer, free);
+    return utf8::utf16to8(std::u16string_view(reinterpret_cast<const char16_t*>(buffer_ptr.get()), result_len));
+#else
+    const auto* result = std::getenv(name.c_str());
+    if(result == nullptr) return std::nullopt;
+    return std::string(result);
+#endif
+}

--- a/snail/common/system.hpp
+++ b/snail/common/system.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace snail::common {
+
+std::filesystem::path get_temp_dir() noexcept;
+
+std::optional<std::filesystem::path> get_home_dir() noexcept;
+
+std::optional<std::string> get_env_var(const std::string& name) noexcept;
+
+} // namespace snail::common


### PR DESCRIPTION
To describe how the binary modules should be found it is now possible to provide the DWARF resolver with additional options. These include some local file directories to search for the binary in. A path map allows to map paths from the input-files to paths on the current file-system.

If the files cannot be found locally, we can now provide a build-id to the DWARF symbol resolver and it will try to download the necessary debug symbols from a debuginfod server.
