### PR TITLE
Extract build-ids from perf.data files

### DIFF
--- a/snail/analysis/detail/perf_data_file_process_context.cpp
+++ b/snail/analysis/detail/perf_data_file_process_context.cpp
@@ -117,13 +117,22 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::mmap2
 {
     auto& process_modules = modules_per_process[event.pid()];
 
+    std::optional<perf_data::build_id> build_id;
+    if(event.has_build_id())
+    {
+        build_id.emplace();
+        build_id->size_ = event.build_id().size();
+        std::ranges::copy(event.build_id(), build_id->buffer_.begin());
+    }
+
     assert(event.sample_id().time);
     process_modules.insert(detail::module_info<module_data>{
                                .base    = event.addr(),
                                .size    = event.len(),
                                .payload = {
                                            .filename    = std::string(event.filename()),
-                                           .page_offset = event.pgoff()}
+                                           .page_offset = event.pgoff(),
+                                           .build_id    = build_id}
     },
                            *event.sample_id().time);
 }

--- a/snail/analysis/detail/perf_data_file_process_context.hpp
+++ b/snail/analysis/detail/perf_data_file_process_context.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <set>
 
+#include <snail/perf_data/build_id.hpp>
 #include <snail/perf_data/dispatching_event_observer.hpp>
 
 #include <snail/analysis/detail/module_map.hpp>
@@ -58,13 +59,15 @@ public:
 
     struct module_data
     {
-        std::string   filename;
-        std::uint64_t page_offset;
+        std::string                        filename;
+        std::uint64_t                      page_offset;
+        std::optional<perf_data::build_id> build_id;
 
         [[nodiscard]] friend bool operator==(const module_data& lhs, const module_data& rhs)
         {
             return lhs.filename == rhs.filename &&
-                   lhs.page_offset == rhs.page_offset;
+                   lhs.page_offset == rhs.page_offset &&
+                   lhs.build_id == rhs.build_id;
         }
     };
 

--- a/snail/analysis/perf_data_data_provider.hpp
+++ b/snail/analysis/perf_data_data_provider.hpp
@@ -3,8 +3,13 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 
 #include <snail/analysis/data_provider.hpp>
+#include <snail/analysis/options.hpp>
+#include <snail/analysis/path_map.hpp>
+
+#include <snail/perf_data/build_id.hpp>
 
 namespace snail::analysis {
 
@@ -18,6 +23,9 @@ class dwarf_resolver;
 class perf_data_data_provider : public data_provider
 {
 public:
+    perf_data_data_provider(dwarf_symbol_find_options find_options    = {},
+                            path_map                  module_path_map = {});
+
     virtual ~perf_data_data_provider();
 
     virtual void process(const std::filesystem::path& file_path) override;
@@ -38,8 +46,9 @@ private:
     std::unique_ptr<detail::perf_data_file_process_context> process_context_;
     std::unique_ptr<detail::dwarf_resolver>                 symbol_resolver_;
 
-    std::optional<analysis::session_info> session_info_;
-    std::optional<analysis::system_info>  system_info_;
+    std::optional<std::unordered_map<std::string, perf_data::build_id>> build_id_map_;
+    std::optional<analysis::session_info>                               session_info_;
+    std::optional<analysis::system_info>                                system_info_;
 
     common::timestamp_t session_start_time_;
     common::timestamp_t session_end_time_;


### PR DESCRIPTION
Adds support to extract build-ids from perf.data files and pass them to the DWARF resolver, so that the resolver can fetch the symbols from a debuginfod server.