### PR TITLE
Extract info from XPerf events

### DIFF
--- a/snail/analysis/detail/etl_file_process_context.cpp
+++ b/snail/analysis/detail/etl_file_process_context.cpp
@@ -37,6 +37,7 @@ etl_file_process_context::etl_file_process_context()
     register_event<etl::parser::system_config_v2_physical_disk_event_view>();
     register_event<etl::parser::system_config_v2_logical_disk_event_view>();
     register_event<etl::parser::system_config_v5_pnp_event_view>();
+    register_event<etl::parser::system_config_ex_v0_build_info_event_view>();
     register_event<etl::parser::system_config_ex_v0_system_paths_event_view>();
     register_event<etl::parser::system_config_ex_v0_volume_mapping_event_view>();
     register_event<etl::parser::process_v4_type_group1_event_view>();
@@ -189,6 +190,15 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
     {
         processor_name_ = event.friendly_name();
     }
+}
+
+void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*file_header*/,
+                                            const etl::common_trace_header& /*header*/,
+                                            const etl::parser::system_config_ex_v0_build_info_event_view& event)
+{
+    if(os_name_) return;
+
+    os_name_ = event.product_name();
 }
 
 void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*file_header*/,
@@ -369,4 +379,10 @@ std::optional<std::u16string_view> etl_file_process_context::processor_name() co
 {
     if(!processor_name_) return std::nullopt;
     return *processor_name_;
+}
+
+std::optional<std::u16string_view> etl_file_process_context::os_name() const
+{
+    if(!os_name_) return std::nullopt;
+    return *os_name_;
 }

--- a/snail/analysis/detail/etl_file_process_context.hpp
+++ b/snail/analysis/detail/etl_file_process_context.hpp
@@ -22,6 +22,8 @@ struct system_config_v3_cpu_event_view;
 struct system_config_v2_physical_disk_event_view;
 struct system_config_v2_logical_disk_event_view;
 struct system_config_v5_pnp_event_view;
+struct system_config_ex_v0_system_paths_event_view;
+struct system_config_ex_v0_volume_mapping_event_view;
 struct process_v4_type_group1_event_view;
 struct thread_v3_type_group1_event_view;
 struct image_v3_load_event_view;
@@ -120,6 +122,8 @@ private:
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v2_physical_disk_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v2_logical_disk_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v5_pnp_event_view& event);
+    void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_ex_v0_system_paths_event_view& event);
+    void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_ex_v0_volume_mapping_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::process_v4_type_group1_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::thread_v3_type_group1_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::image_v3_load_event_view& event);
@@ -131,6 +135,9 @@ private:
 
     std::map<std::uint32_t, std::uint32_t>         number_of_partitions_per_disk;
     std::unordered_map<std::uint32_t, std::string> nt_partition_to_dos_volume_mapping;
+
+    std::unordered_map<std::string, std::string> nt_to_dos_path_map_;
+    std::optional<std::string>                   system_root_;
 
     process_history processes;
     thread_history  threads;

--- a/snail/analysis/detail/etl_file_process_context.hpp
+++ b/snail/analysis/detail/etl_file_process_context.hpp
@@ -22,6 +22,7 @@ struct system_config_v3_cpu_event_view;
 struct system_config_v2_physical_disk_event_view;
 struct system_config_v2_logical_disk_event_view;
 struct system_config_v5_pnp_event_view;
+struct system_config_ex_v0_build_info_event_view;
 struct system_config_ex_v0_system_paths_event_view;
 struct system_config_ex_v0_volume_mapping_event_view;
 struct process_v4_type_group1_event_view;
@@ -113,6 +114,7 @@ public:
     std::optional<std::u16string_view> computer_name() const;
     std::optional<std::uint16_t>       processor_architecture() const;
     std::optional<std::u16string_view> processor_name() const;
+    std::optional<std::u16string_view> os_name() const;
 
 private:
     template<typename T>
@@ -122,6 +124,7 @@ private:
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v2_physical_disk_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v2_logical_disk_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_v5_pnp_event_view& event);
+    void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_ex_v0_build_info_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_ex_v0_system_paths_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::system_config_ex_v0_volume_mapping_event_view& event);
     void handle_event(const etl::etl_file::header_data& file_header, const etl::common_trace_header& header, const etl::parser::process_v4_type_group1_event_view& event);
@@ -155,6 +158,7 @@ private:
     std::optional<std::u16string> computer_name_;
     std::optional<std::uint16_t>  processor_architecture_;
     std::optional<std::u16string> processor_name_;
+    std::optional<std::u16string> os_name_;
 };
 
 struct etl_file_process_context::profiler_process_info

--- a/snail/analysis/detail/pdb_info.hpp
+++ b/snail/analysis/detail/pdb_info.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <snail/common/guid.hpp>
+
+namespace snail::analysis::detail {
+
+struct pdb_info
+{
+    std::string   pdb_name;
+    common::guid  guid;
+    std::uint32_t age;
+
+    [[nodiscard]] friend bool operator==(const pdb_info& lhs, const pdb_info& rhs)
+    {
+        return lhs.pdb_name == rhs.pdb_name &&
+               lhs.guid == rhs.guid &&
+               lhs.age == rhs.age;
+    }
+};
+
+} // namespace snail::analysis::detail

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -197,7 +197,7 @@ void etl_data_provider::process(const std::filesystem::path& file_path)
 
     system_info_ = analysis::system_info{
         .hostname             = process_context_->computer_name() ? utf8::utf16to8(*process_context_->computer_name()) : "[unknown]",
-        .platform             = "Windows",
+        .platform             = process_context_->os_name() ? utf8::utf16to8(*process_context_->os_name()) : "Windows",
         .architecture         = process_context_->processor_architecture() ? win_architecture_to_str(*process_context_->processor_architecture()) : "[unknown]",
         .cpu_name             = process_context_->processor_name() ? utf8::utf16to8(*process_context_->processor_name()) : "[unknown]",
         .number_of_processors = file.header().number_of_processors,


### PR DESCRIPTION
Adds support to read information from the events added by `xperf -merge` (which is internally done by `vsdiagnostics.exe`). We use the extended system config events to extract volume mappings, system paths and the OS name. The information from the xperf events (if present) will take precedence over the volume mappings we build ourselves from information in the kernels physical and logical disk events.

Additionally, we extract PDB information from xperf's image events and attach it to the module's info. This is supposed to be used in the symbol resolver to download missing PDB from a symbol server.