### PR TITLE
Support downloading PDBs from symbol servers

### DIFF
--- a/snail/analysis/CMakeLists.txt
+++ b/snail/analysis/CMakeLists.txt
@@ -55,6 +55,9 @@ if(SNAIL_WITH_LLVM)
     set_source_files_properties(detail/pdb_resolver.cpp PROPERTIES COMPILE_OPTIONS ${CMAKE_CXX20_STANDARD_COMPILE_OPTION})
     set_source_files_properties(detail/dwarf_resolver.cpp PROPERTIES COMPILE_OPTIONS ${CMAKE_CXX20_STANDARD_COMPILE_OPTION})
   endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    set_source_files_properties(detail/pdb_resolver.cpp PROPERTIES COMPILE_OPTIONS "/wd4702")
+  endif()
 endif()
 
 target_include_directories(analysis SYSTEM PRIVATE

--- a/snail/analysis/diagsession_data_provider.cpp
+++ b/snail/analysis/diagsession_data_provider.cpp
@@ -33,6 +33,11 @@ std::optional<std::string_view> extract_xml_attribute(std::string_view xml_node,
 
 } // namespace
 
+diagsession_data_provider::diagsession_data_provider(pdb_symbol_find_options find_options,
+                                                     path_map                module_path_map) :
+    etl_data_provider(std::move(find_options), std::move(module_path_map))
+{}
+
 diagsession_data_provider::~diagsession_data_provider()
 {
     try_cleanup();

--- a/snail/analysis/diagsession_data_provider.hpp
+++ b/snail/analysis/diagsession_data_provider.hpp
@@ -9,6 +9,9 @@ namespace snail::analysis {
 class diagsession_data_provider : public etl_data_provider
 {
 public:
+    diagsession_data_provider(pdb_symbol_find_options find_options    = {},
+                              path_map                module_path_map = {});
+
     virtual ~diagsession_data_provider();
 
     virtual void process(const std::filesystem::path& file_path) override;

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -75,6 +75,8 @@ struct etl_sample_data : public sample_data
                                          resolver->resolve_symbol(detail::pdb_resolver::module_info{
                                                                       .image_filename = module->payload.filename,
                                                                       .image_base     = module->base,
+                                                                      .checksum       = module->payload.checksum,
+                                                                      .pdb_info       = module->payload.pdb_info,
                                                                       .process_id     = process_id,
                                                                       .load_timestamp = load_timestamp},
                                                                   instruction_pointer);
@@ -98,6 +100,8 @@ struct etl_sample_data : public sample_data
                                          resolver->resolve_symbol(detail::pdb_resolver::module_info{
                                                                       .image_filename = module->payload.filename,
                                                                       .image_base     = module->base,
+                                                                      .checksum       = module->payload.checksum,
+                                                                      .pdb_info       = module->payload.pdb_info,
                                                                       .process_id     = process_id,
                                                                       .load_timestamp = load_timestamp,
                                                                   },
@@ -142,12 +146,17 @@ std::string win_architecture_to_str(std::uint16_t arch)
 
 } // namespace
 
+etl_data_provider::etl_data_provider(pdb_symbol_find_options find_options,
+                                     path_map                module_path_map)
+{
+    symbol_resolver_ = std::make_unique<detail::pdb_resolver>(std::move(find_options), std::move(module_path_map));
+}
+
 etl_data_provider::~etl_data_provider() = default;
 
 void etl_data_provider::process(const std::filesystem::path& file_path)
 {
     process_context_ = std::make_unique<detail::etl_file_process_context>();
-    symbol_resolver_ = std::make_unique<detail::pdb_resolver>();
 
     etl::etl_file file(file_path);
     file.process(process_context_->observer());

--- a/snail/analysis/etl_data_provider.hpp
+++ b/snail/analysis/etl_data_provider.hpp
@@ -5,6 +5,8 @@
 #include <optional>
 
 #include <snail/analysis/data_provider.hpp>
+#include <snail/analysis/options.hpp>
+#include <snail/analysis/path_map.hpp>
 
 namespace snail::analysis {
 
@@ -18,6 +20,9 @@ class pdb_resolver;
 class etl_data_provider : public data_provider
 {
 public:
+    etl_data_provider(pdb_symbol_find_options find_options    = {},
+                      path_map                module_path_map = {});
+
     virtual ~etl_data_provider();
 
     virtual void process(const std::filesystem::path& file_path) override;

--- a/snail/analysis/options.cpp
+++ b/snail/analysis/options.cpp
@@ -6,6 +6,12 @@
 
 using namespace snail::analysis;
 
+pdb_symbol_find_options::pdb_symbol_find_options() :
+    symbol_cache_dir_(common::get_temp_dir() / "SymbolCache")
+{
+    symbol_server_urls_.push_back("https://msdl.microsoft.com/download/symbols");
+}
+
 dwarf_symbol_find_options::dwarf_symbol_find_options()
 {
     const auto cache_path_env = common::get_env_var("DEBUGINFOD_CACHE_PATH");

--- a/snail/analysis/options.hpp
+++ b/snail/analysis/options.hpp
@@ -6,6 +6,16 @@
 
 namespace snail::analysis {
 
+struct pdb_symbol_find_options
+{
+    pdb_symbol_find_options();
+
+    std::vector<std::filesystem::path> search_dirs_;
+
+    std::filesystem::path    symbol_cache_dir_;
+    std::vector<std::string> symbol_server_urls_;
+};
+
 struct dwarf_symbol_find_options
 {
     dwarf_symbol_find_options();

--- a/snail/common/parser/extract.hpp
+++ b/snail/common/parser/extract.hpp
@@ -26,7 +26,16 @@ T extract(std::span<const std::byte> data, std::size_t bytes_offset, [[maybe_unu
     {
         if(data_byte_order != std::endian::native)
         {
+#ifdef __cpp_lib_byteswap
             return std::byteswap(value);
+#elif defined(__has_builtin) && __has_builtin(__builtin_bswap16) && __has_builtin(__builtin_bswap32) && __has_builtin(__builtin_bswap64)
+            static_assert(sizeof(T) <= 8);
+            if constexpr(sizeof(T) == 2) return __builtin_bswap16(value);
+            else if constexpr(sizeof(T) == 4) return __builtin_bswap32(value);
+            else return __builtin_bswap64(value);
+#else
+#    error "Missing byteswap operation"
+#endif
         }
         else
         {


### PR DESCRIPTION
This MR introduces support to download PDBs from symbol server based on the PDB symbol information in the trace or in the binaries if they are available on the machine.