### PR TITLE
Sample filter

### DIFF
--- a/apps/analysis.cpp
+++ b/apps/analysis.cpp
@@ -90,8 +90,12 @@ int main(int argc, char* argv[])
 
     for(const auto process_id : provider->sampling_processes())
     {
-        const auto result = snail::analysis::analyze_stacks(*provider, provider->process_info(process_id));
-        std::cout << result.process.name << " (" << result.process.id << "):\n";
+        const auto process_info    = provider->process_info(process_id);
+        const auto stacks_analysis = snail::analysis::analyze_stacks(*provider, process_id);
+        std::cout << process_info.name << " (" << process_info.os_id << "):\n";
+        std::cout << "  Modules:   " << stacks_analysis.all_modules().size() << "\n";
+        std::cout << "  Functions: " << stacks_analysis.all_functions().size() << "\n";
+        std::cout << "  Files:     " << stacks_analysis.all_files().size() << "\n";
     }
 
     return EXIT_SUCCESS;

--- a/apps/etl_file.cpp
+++ b/apps/etl_file.cpp
@@ -29,7 +29,6 @@
 #include <snail/etl/parser/records/visual_studio/diagnostics_hub.hpp>
 
 #include <snail/common/detail/dump.hpp>
-#include <snail/common/types.hpp>
 
 using namespace snail;
 
@@ -162,8 +161,8 @@ struct options
     bool show_config_ex = false;
     bool show_vs_diag   = false;
 
-    std::optional<common::process_id_t> process_of_interest;
-    bool                                all_processes = false;
+    std::optional<std::uint32_t> process_of_interest;
+    bool                         all_processes = false;
 
     std::vector<std::string> only;
     std::vector<std::string> except;

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -151,6 +151,18 @@
                 "kind": "reference",
                 "name": "RetrieveLineInfoParams"
             }
+        },
+        {
+            "method": "setSampleFilters",
+            "messageDirection": "clientToServer",
+            "result": {
+                "kind": "base",
+                "name": "null"
+            },
+            "params": {
+                "kind": "reference",
+                "name": "SetSampleFiltersParams"
+            }
         }
     ],
     "notifications": [
@@ -1130,6 +1142,35 @@
                         }
                     },
                     "documentation": "Modules to include when `mode` is `IncludedOnly`. Supports wildcards (as in '*.exe')."
+                }
+            ]
+        },
+        {
+            "name": "SetSampleFiltersParams",
+            "extends": [
+                {
+                    "kind": "reference",
+                    "name": "_DocumentIdParams"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "minTime",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    },
+                    "optional": true,
+                    "documentation": "In nanoseconds since session start."
+                },
+                {
+                    "name": "maxTime",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    },
+                    "optional": true,
+                    "documentation": "In nanoseconds since session start."
                 }
             ]
         }

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -216,7 +216,14 @@
             "name": "ThreadInfo",
             "properties": [
                 {
-                    "name": "id",
+                    "name": "key",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    }
+                },
+                {
+                    "name": "osId",
                     "type": {
                         "kind": "base",
                         "name": "uinteger"
@@ -252,7 +259,14 @@
             "name": "ProcessInfo",
             "properties": [
                 {
-                    "name": "id",
+                    "name": "key",
+                    "type": {
+                        "kind": "base",
+                        "name": "uinteger"
+                    }
+                },
+                {
+                    "name": "osId",
                     "type": {
                         "kind": "base",
                         "name": "uinteger"
@@ -539,7 +553,7 @@
             "name": "ProcessFunction",
             "properties": [
                 {
-                    "name": "processId",
+                    "name": "processKey",
                     "type": {
                         "kind": "base",
                         "name": "uinteger"
@@ -611,7 +625,7 @@
             "name": "_ProcessParams",
             "properties": [
                 {
-                    "name": "processId",
+                    "name": "processKey",
                     "type": {
                         "kind": "base",
                         "name": "uinteger"

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -1185,6 +1185,26 @@
                     },
                     "optional": true,
                     "documentation": "In nanoseconds since session start."
+                },
+                {
+                    "name": "excludedProcesses",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "uinteger"
+                        }
+                    }
+                },
+                {
+                    "name": "excludedThreads",
+                    "type": {
+                        "kind": "array",
+                        "element": {
+                            "kind": "base",
+                            "name": "uinteger"
+                        }
+                    }
                 }
             ]
         }

--- a/snail/analysis/analysis.cpp
+++ b/snail/analysis/analysis.cpp
@@ -175,7 +175,8 @@ const call_tree_node& stacks_analysis::get_call_tree_node(call_tree_node::id_t i
 }
 
 stacks_analysis snail::analysis::analyze_stacks(const samples_provider& provider,
-                                                process_info            process)
+                                                process_info            process,
+                                                const sample_filter&    filter)
 {
     std::unordered_map<std::string, module_info::id_t>                               modules_by_name;
     std::unordered_map<std::pair<module_info::id_t, std::string>, module_info::id_t> functions_by_name;
@@ -203,7 +204,7 @@ stacks_analysis snail::analysis::analyze_stacks(const samples_provider& provider
         .children    = {},
     };
 
-    for(const auto& sample : provider.samples(result.process.id))
+    for(const auto& sample : provider.samples(result.process.id, filter))
     {
         ++result.call_tree_root.hits.total;
         ++result.function_root.hits.total;

--- a/snail/analysis/analysis.cpp
+++ b/snail/analysis/analysis.cpp
@@ -175,7 +175,7 @@ const call_tree_node& stacks_analysis::get_call_tree_node(call_tree_node::id_t i
 }
 
 stacks_analysis snail::analysis::analyze_stacks(const samples_provider& provider,
-                                                process_info            process,
+                                                unique_process_id       process_id,
                                                 const sample_filter&    filter)
 {
     std::unordered_map<std::string, module_info::id_t>                               modules_by_name;
@@ -183,7 +183,7 @@ stacks_analysis snail::analysis::analyze_stacks(const samples_provider& provider
     std::unordered_map<std::string, file_info::id_t>                                 files_by_path;
 
     stacks_analysis result;
-    result.process = std::move(process);
+    result.process_id = process_id;
 
     result.function_root = function_info{
         .id           = stacks_analysis::root_function_id,
@@ -204,7 +204,7 @@ stacks_analysis snail::analysis::analyze_stacks(const samples_provider& provider
         .children    = {},
     };
 
-    for(const auto& sample : provider.samples(result.process.id, filter))
+    for(const auto& sample : provider.samples(process_id, filter))
     {
         ++result.call_tree_root.hits.total;
         ++result.function_root.hits.total;

--- a/snail/analysis/analysis.hpp
+++ b/snail/analysis/analysis.hpp
@@ -2,11 +2,10 @@
 
 #include <limits>
 
-#include <snail/common/types.hpp>
-
 #include <snail/analysis/data/call_tree.hpp>
 #include <snail/analysis/data/file.hpp>
 #include <snail/analysis/data/functions.hpp>
+#include <snail/analysis/data/ids.hpp>
 #include <snail/analysis/data/modules.hpp>
 #include <snail/analysis/data/process.hpp>
 
@@ -19,12 +18,12 @@ class samples_provider;
 struct stacks_analysis;
 
 stacks_analysis analyze_stacks(const samples_provider& provider,
-                               process_info            process,
+                               unique_process_id       process_id,
                                const sample_filter&    filter = {});
 
 struct stacks_analysis
 {
-    process_info process;
+    unique_process_id process_id;
 
     const module_info& get_module(module_info::id_t id) const;
 
@@ -42,7 +41,7 @@ struct stacks_analysis
 
 private:
     friend stacks_analysis analyze_stacks(const samples_provider& provider,
-                                          process_info            process,
+                                          unique_process_id       process_id,
                                           const sample_filter&    filter);
 
     // FIXME: This is a workaround: we would like to use the max of std::size_t, but since we will

--- a/snail/analysis/analysis.hpp
+++ b/snail/analysis/analysis.hpp
@@ -10,6 +10,8 @@
 #include <snail/analysis/data/modules.hpp>
 #include <snail/analysis/data/process.hpp>
 
+#include <snail/analysis/options.hpp>
+
 namespace snail::analysis {
 
 class samples_provider;
@@ -17,7 +19,8 @@ class samples_provider;
 struct stacks_analysis;
 
 stacks_analysis analyze_stacks(const samples_provider& provider,
-                               process_info            process);
+                               process_info            process,
+                               const sample_filter&    filter = {});
 
 struct stacks_analysis
 {
@@ -39,7 +42,8 @@ struct stacks_analysis
 
 private:
     friend stacks_analysis analyze_stacks(const samples_provider& provider,
-                                          process_info            process);
+                                          process_info            process,
+                                          const sample_filter&    filter);
 
     // FIXME: This is a workaround: we would like to use the max of std::size_t, but since we will
     //        serialize those values to JSON and eventually handle them in JavaScript which cannot

--- a/snail/analysis/data/ids.hpp
+++ b/snail/analysis/data/ids.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+#include <functional>
+
+namespace snail::analysis {
+
+struct unique_process_id
+{
+    std::uint64_t key;
+
+    [[nodiscard]] inline auto operator<=>(const unique_process_id& other) const = default;
+};
+
+struct unique_thread_id
+{
+    std::uint64_t key;
+
+    [[nodiscard]] inline auto operator<=>(const unique_thread_id& other) const = default;
+};
+
+} // namespace snail::analysis
+
+template<>
+struct std::hash<snail::analysis::unique_process_id>
+{
+    [[nodiscard]] inline size_t operator()(const snail::analysis::unique_process_id& id) const noexcept
+    {
+        return std::hash<std::uint64_t>()(id.key);
+    }
+};
+
+template<>
+struct std::hash<snail::analysis::unique_thread_id>
+{
+    [[nodiscard]] inline size_t operator()(const snail::analysis::unique_thread_id& id) const noexcept
+    {
+        return std::hash<std::uint64_t>()(id.key);
+    }
+};

--- a/snail/analysis/data/process.hpp
+++ b/snail/analysis/data/process.hpp
@@ -3,13 +3,15 @@
 #include <chrono>
 #include <string>
 
-#include <snail/common/types.hpp>
+#include <snail/analysis/data/ids.hpp>
 
 namespace snail::analysis {
 
 struct process_info
 {
-    common::process_id_t id;
+    unique_process_id unique_id;
+
+    std::uint32_t os_id;
 
     std::string name;
 

--- a/snail/analysis/data/stack.hpp
+++ b/snail/analysis/data/stack.hpp
@@ -2,8 +2,6 @@
 
 #include <string_view>
 
-#include <snail/common/types.hpp>
-
 namespace snail::analysis {
 
 struct stack_frame

--- a/snail/analysis/data/thread.hpp
+++ b/snail/analysis/data/thread.hpp
@@ -4,13 +4,15 @@
 #include <optional>
 #include <string>
 
-#include <snail/common/types.hpp>
+#include <snail/analysis/data/ids.hpp>
 
 namespace snail::analysis {
 
 struct thread_info
 {
-    common::thread_id_t id;
+    unique_thread_id unique_id;
+
+    std::uint32_t os_id;
 
     std::optional<std::string> name;
 

--- a/snail/analysis/data_provider.hpp
+++ b/snail/analysis/data_provider.hpp
@@ -36,6 +36,9 @@ public:
 
     virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter = {}) const = 0;
+
+    virtual std::size_t count_samples(unique_process_id    process_id,
+                                      const sample_filter& filter = {}) const = 0;
 };
 
 class info_provider

--- a/snail/analysis/data_provider.hpp
+++ b/snail/analysis/data_provider.hpp
@@ -35,7 +35,8 @@ class samples_provider
 public:
     virtual ~samples_provider() = default;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id) const = 0;
+    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+                                                          const sample_filter& filter = {}) const = 0;
 };
 
 class info_provider

--- a/snail/analysis/data_provider.hpp
+++ b/snail/analysis/data_provider.hpp
@@ -7,8 +7,7 @@
 
 #include <snail/common/generator.hpp>
 
-#include <snail/common/types.hpp>
-
+#include <snail/analysis/data/ids.hpp>
 #include <snail/analysis/data/process.hpp>
 #include <snail/analysis/data/session.hpp>
 #include <snail/analysis/data/stack.hpp>
@@ -35,7 +34,7 @@ class samples_provider
 public:
     virtual ~samples_provider() = default;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+    virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter = {}) const = 0;
 };
 
@@ -54,11 +53,11 @@ class process_provider
 public:
     virtual ~process_provider() = default;
 
-    virtual common::generator<common::process_id_t> sampling_processes() const = 0;
+    virtual common::generator<unique_process_id> sampling_processes() const = 0;
 
-    virtual analysis::process_info process_info(common::process_id_t process_id) const = 0;
+    virtual analysis::process_info process_info(unique_process_id process_id) const = 0;
 
-    virtual common::generator<analysis::thread_info> threads_info(common::process_id_t process_id) const = 0;
+    virtual common::generator<analysis::thread_info> threads_info(unique_process_id process_id) const = 0;
 };
 
 class file_processor

--- a/snail/analysis/detail/dwarf_resolver.hpp
+++ b/snail/analysis/detail/dwarf_resolver.hpp
@@ -17,7 +17,7 @@ namespace snail::analysis::detail {
 class dwarf_resolver
 {
 public:
-    using process_id_t          = std::uint32_t;
+    using os_pid_t              = std::uint32_t;
     using timestamp_t           = std::uint64_t;
     using instruction_pointer_t = std::uint64_t;
 
@@ -38,8 +38,8 @@ public:
 private:
     struct module_key
     {
-        process_id_t process_id;
-        timestamp_t  load_timestamp;
+        os_pid_t    process_id;
+        timestamp_t load_timestamp;
 
         bool operator==(const module_key& other) const;
     };
@@ -57,8 +57,8 @@ private:
         std::size_t operator()(const module_key& key) const;
 
     private:
-        std::hash<process_id_t> process_id_hasher;
-        std::hash<timestamp_t>  timestamp_hasher;
+        std::hash<os_pid_t>    process_id_hasher;
+        std::hash<timestamp_t> timestamp_hasher;
     };
 
     struct symbol_key_hasher
@@ -104,8 +104,8 @@ struct dwarf_resolver::module_info
     instruction_pointer_t image_base;
     instruction_pointer_t page_offset;
 
-    process_id_t process_id;
-    timestamp_t  load_timestamp;
+    os_pid_t    process_id;
+    timestamp_t load_timestamp;
 };
 
 } // namespace snail::analysis::detail

--- a/snail/analysis/detail/etl_file_process_context.cpp
+++ b/snail/analysis/detail/etl_file_process_context.cpp
@@ -328,7 +328,9 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
         .timestamp           = header.timestamp,
         .instruction_pointer = event.instruction_pointer(),
         .user_mode_stack     = {},
+        .user_timestamp      = {},
         .kernel_mode_stack   = {},
+        .kernel_timestamp    = {},
     });
 }
 
@@ -358,8 +360,9 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data&   
 
         assert(sample.timestamp == sample_timestamp);
 
-        const auto starts_in_kernel   = is_kernel_address(event.stack().back(), file_header.pointer_size);
-        auto&      sample_stack_index = starts_in_kernel ? sample.kernel_mode_stack : sample.user_mode_stack;
+        const auto starts_in_kernel       = is_kernel_address(event.stack().back(), file_header.pointer_size);
+        auto&      sample_stack_index     = starts_in_kernel ? sample.kernel_mode_stack : sample.user_mode_stack;
+        auto&      sample_stack_timestamp = starts_in_kernel ? sample.kernel_timestamp : sample.user_timestamp;
 
         // Usually, we should have one user mode stack and optionally one kernel mode stack.
         // But it seems that we can sometimes have multiple kernel mode stacks for a single sample.
@@ -368,7 +371,8 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data&   
         // for know, we just replace the old stack.
         assert(sample_stack_index == std::nullopt || starts_in_kernel);
 
-        sample_stack_index = stacks.insert(event.stack());
+        sample_stack_index     = stacks.insert(event.stack());
+        sample_stack_timestamp = header.timestamp;
 
         break;
     }

--- a/snail/analysis/detail/etl_file_process_context.cpp
+++ b/snail/analysis/detail/etl_file_process_context.cpp
@@ -17,6 +17,7 @@
 #include <snail/etl/parser/records/visual_studio/diagnostics_hub.hpp>
 
 using namespace snail;
+using namespace snail::analysis;
 using namespace snail::analysis::detail;
 
 namespace {
@@ -63,7 +64,47 @@ void etl_file_process_context::finish()
 
     static constexpr std::string_view default_system_root = "C:\\WINDOWS\\";
 
-    for(auto& [process_id, process_module_map] : modules_per_process)
+    // Assign unique IDs to processes and threads.
+    unique_process_id next_process_id{.key = 0x100000000};
+    for(auto& [id, entries] : processes.all_entries())
+    {
+        for(auto& entry : entries)
+        {
+            entry.payload.unique_id = next_process_id;
+            ++next_process_id.key;
+
+            unique_process_id_to_key_[*entry.payload.unique_id] = process_key{id, entry.timestamp};
+        }
+    }
+    unique_thread_id next_thread_id{.key = 0x200000000};
+    for(auto& [id, entries] : threads.all_entries())
+    {
+        for(auto& entry : entries)
+        {
+            entry.payload.unique_id = next_thread_id;
+            ++next_thread_id.key;
+
+            unique_thread_id_to_key_[*entry.payload.unique_id] = thread_key{id, entry.timestamp};
+        }
+    }
+
+    // Build threads per proccess map
+    for(const auto& [process_id, process_threads] : threads_per_process_id_)
+    {
+        for(const auto& thread_key : process_threads)
+        {
+            const auto* const process = processes.find_at(process_id, thread_key.time);
+            if(process == nullptr) continue;
+
+            const auto* const thread = threads.find_at(thread_key.id, thread_key.time);
+            if(thread == nullptr) continue;
+
+            threads_per_process_[*process->payload.unique_id].insert(*thread->payload.unique_id);
+        }
+    }
+
+    // Map NT to DOS paths
+    for(auto& [process_id, process_module_map] : modules_per_process_id_)
     {
         for(auto& module : process_module_map.all_modules())
         {
@@ -110,7 +151,17 @@ void etl_file_process_context::finish()
     }
 }
 
-const std::unordered_map<etl_file_process_context::process_id_t, etl_file_process_context::profiler_process_info>& etl_file_process_context::profiler_processes() const
+etl_file_process_context::process_key etl_file_process_context::id_to_key(unique_process_id id) const
+{
+    return unique_process_id_to_key_.at(id);
+}
+
+etl_file_process_context::thread_key etl_file_process_context::id_to_key(unique_thread_id id) const
+{
+    return unique_thread_id_to_key_.at(id);
+}
+
+const std::unordered_map<etl_file_process_context::process_key, etl_file_process_context::profiler_process_info>& etl_file_process_context::profiler_processes() const
 {
     return profiler_processes_;
 }
@@ -125,14 +176,14 @@ const etl_file_process_context::thread_history& etl_file_process_context::get_th
     return threads;
 }
 
-const std::set<std::pair<etl_file_process_context::thread_id_t, etl_file_process_context::timestamp_t>>& etl_file_process_context::get_process_threads(process_id_t process_id) const
+const std::set<unique_thread_id>& etl_file_process_context::get_process_threads(unique_process_id process_id) const
 {
     return threads_per_process_.at(process_id);
 }
 
-const module_map<etl_file_process_context::module_data>& etl_file_process_context::get_modules(process_id_t process_id) const
+const module_map<etl_file_process_context::module_data, etl_file_process_context::timestamp_t>& etl_file_process_context::get_modules(os_pid_t process_id) const
 {
-    return modules_per_process.at(process_id);
+    return modules_per_process_id_.at(process_id);
 }
 
 template<typename T>
@@ -225,9 +276,12 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
     if(header.type == 1 || header.type == 3) // load || dc_start
     {
         processes.insert(event.process_id(), header.timestamp,
-                         process_data{.image_filename = utf8::replace_invalid(event.image_filename()),
-                                      .command_line   = std::u16string(event.command_line()),
-                                      .end_time       = {}});
+                         process_data{
+                             .image_filename = utf8::replace_invalid(event.image_filename()),
+                             .command_line   = std::u16string(event.command_line()),
+                             .end_time       = {},
+                             .unique_id      = {},
+                         });
     }
     else if(header.type == 2 || header.type == 4) // unload || dc_end
     {
@@ -245,12 +299,17 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
 {
     if(header.type == 1 || header.type == 3) // start || dc_start
     {
+        // const auto name = event.thread_name();
+
         const auto is_new_thread = threads.insert(event.thread_id(), header.timestamp,
-                                                  thread_data{.process_id = event.process_id(),
-                                                              .end_time   = {}});
+                                                  thread_data{
+                                                      .process_id = event.process_id(),
+                                                      .end_time   = {},
+                                                      .unique_id  = {},
+                                                  });
         if(is_new_thread)
         {
-            threads_per_process_[event.process_id()].emplace(event.thread_id(), header.timestamp);
+            threads_per_process_id_[event.process_id()].emplace(event.thread_id(), header.timestamp);
         }
     }
     else if(header.type == 2 || header.type == 4) // end || dc_end
@@ -269,8 +328,8 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
 {
     if(header.type != 10 && header.type != 3) return; // We do only handle load events
 
-    auto& modules   = modules_per_process[event.process_id()];
-    auto& pdb_infos = modules_pdb_info_per_process[event.process_id()];
+    auto& modules   = modules_per_process_id_[event.process_id()];
+    auto& pdb_infos = modules_pdb_info_per_process_id_[event.process_id()];
 
     const auto image_base = event.image_base();
 
@@ -304,7 +363,7 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
                                             const etl::common_trace_header&                            header,
                                             const etl::parser::image_id_v2_dbg_id_pdb_info_event_view& event)
 {
-    auto& pdb_infos = modules_pdb_info_per_process[event.process_id()];
+    auto& pdb_infos = modules_pdb_info_per_process_id_[event.process_id()];
 
     pdb_infos.push_back(pdb_info_storage{
         .event_timestamp = header.timestamp,
@@ -321,7 +380,7 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
                                             const etl::parser::perfinfo_v2_sampled_profile_event_view& event)
 {
     const auto thread_id      = event.thread_id();
-    auto&      thread_samples = samples_per_thread[thread_id];
+    auto&      thread_samples = samples_per_thread_id_[thread_id];
 
     thread_samples.push_back(sample_info{
         .thread_id           = thread_id,
@@ -340,8 +399,8 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data&   
 {
     const auto thread_id = event.thread_id();
 
-    auto iter = samples_per_thread.find(thread_id);
-    if(iter == samples_per_thread.end()) return;
+    auto iter = samples_per_thread_id_.find(thread_id);
+    if(iter == samples_per_thread_id_.end()) return;
 
     const auto sample_timestamp = event.event_timestamp();
 
@@ -382,16 +441,17 @@ void etl_file_process_context::handle_event(const etl::etl_file::header_data& /*
                                             const etl::common_trace_header&                                            header,
                                             const etl::parser::vs_diagnostics_hub_target_profiling_started_event_view& event)
 {
-    const auto process_id           = event.process_id();
-    profiler_processes_[process_id] = profiler_process_info{
+    const auto process_id = event.process_id();
+
+    profiler_processes_[process_key{process_id, header.timestamp}] = profiler_process_info{
         .process_id      = process_id,
         .start_timestamp = header.timestamp};
 }
 
-std::span<const etl_file_process_context::sample_info> etl_file_process_context::thread_samples(thread_id_t thread_id, timestamp_t start_time, std::optional<timestamp_t> end_time) const
+std::span<const etl_file_process_context::sample_info> etl_file_process_context::thread_samples(os_tid_t thread_id, timestamp_t start_time, std::optional<timestamp_t> end_time) const
 {
-    auto iter = samples_per_thread.find(thread_id);
-    if(iter == samples_per_thread.end()) return {};
+    auto iter = samples_per_thread_id_.find(thread_id);
+    if(iter == samples_per_thread_id_.end()) return {};
 
     const auto& thread_samples = iter->second;
 
@@ -401,6 +461,8 @@ std::span<const etl_file_process_context::sample_info> etl_file_process_context:
     const auto range_end_iter = end_time != std::nullopt ?
                                     std::ranges::upper_bound(thread_samples, *end_time, std::less<>(), &sample_info::timestamp) :
                                     thread_samples.end();
+
+    if(range_first_iter > range_end_iter) return {};
 
     return std::span(thread_samples).subspan(range_first_iter - thread_samples.begin(), range_end_iter - range_first_iter);
 }

--- a/snail/analysis/detail/etl_file_process_context.hpp
+++ b/snail/analysis/detail/etl_file_process_context.hpp
@@ -193,7 +193,10 @@ struct etl_file_process_context::sample_info
     instruction_pointer_t instruction_pointer;
 
     std::optional<std::size_t> user_mode_stack;
+    timestamp_t                user_timestamp;
+
     std::optional<std::size_t> kernel_mode_stack;
+    timestamp_t                kernel_timestamp;
 };
 
 } // namespace snail::analysis::detail

--- a/snail/analysis/detail/id_at.hpp
+++ b/snail/analysis/detail/id_at.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <functional>
+
+#include <snail/common/hash_combine.hpp>
+
+namespace snail::analysis::detail {
+
+template<typename IdType, typename TimeType>
+struct id_at
+{
+    IdType   id;
+    TimeType time;
+
+    [[nodiscard]] auto operator<=>(const id_at<IdType, TimeType>& other) const = default;
+};
+
+} // namespace snail::analysis::detail
+
+template<typename IdType, typename TimeType>
+struct std::hash<snail::analysis::detail::id_at<IdType, TimeType>>
+{
+    [[nodiscard]] inline size_t operator()(const snail::analysis::detail::id_at<IdType, TimeType>& key) const noexcept
+    {
+        return snail::common::hash_combine(std::hash<IdType>()(key.id), std::hash<TimeType>()(key.time));
+    }
+};

--- a/snail/analysis/detail/pdb_resolver.hpp
+++ b/snail/analysis/detail/pdb_resolver.hpp
@@ -39,7 +39,7 @@ inline constexpr auto default_use_dia_sdk = platform_supports_dia_sdk;
 class pdb_resolver
 {
 public:
-    using process_id_t          = std::uint32_t;
+    using os_pid_t              = std::uint32_t;
     using timestamp_t           = std::uint64_t;
     using instruction_pointer_t = std::uint64_t;
 
@@ -61,8 +61,8 @@ public:
 private:
     struct module_key
     {
-        process_id_t process_id;
-        timestamp_t  load_timestamp;
+        os_pid_t    process_id;
+        timestamp_t load_timestamp;
 
         bool operator==(const module_key& other) const;
     };
@@ -80,8 +80,8 @@ private:
         std::size_t operator()(const module_key& key) const;
 
     private:
-        std::hash<process_id_t> process_id_hasher;
-        std::hash<timestamp_t>  timestamp_hasher;
+        std::hash<os_pid_t>    process_id_hasher;
+        std::hash<timestamp_t> timestamp_hasher;
     };
 
     struct symbol_key_hasher
@@ -125,8 +125,8 @@ struct pdb_resolver::module_info
     std::uint32_t                   checksum;
     std::optional<detail::pdb_info> pdb_info;
 
-    process_id_t process_id;
-    timestamp_t  load_timestamp;
+    os_pid_t    process_id;
+    timestamp_t load_timestamp;
 };
 
 } // namespace snail::analysis::detail

--- a/snail/analysis/detail/perf_data_file_process_context.cpp
+++ b/snail/analysis/detail/perf_data_file_process_context.cpp
@@ -5,6 +5,7 @@
 #include <snail/perf_data/parser/records/perf.hpp>
 
 using namespace snail;
+using namespace snail::analysis;
 using namespace snail::analysis::detail;
 
 perf_data_file_process_context::perf_data_file_process_context()
@@ -24,6 +25,7 @@ perf_data::dispatching_event_observer& perf_data_file_process_context::observer(
 
 void perf_data_file_process_context::finish()
 {
+    // Assign names to processes & threads (and create missing ones)
     for(const auto& [id, entries] : process_names.all_entries())
     {
         for(const auto& entry : entries)
@@ -36,8 +38,9 @@ void perf_data_file_process_context::finish()
             else
             {
                 processes.insert(id, entry.timestamp, process_data{
-                                                          .name     = entry.payload.name,
-                                                          .end_time = {},
+                                                          .name      = entry.payload.name,
+                                                          .end_time  = {},
+                                                          .unique_id = {},
                                                       });
             }
         }
@@ -57,11 +60,115 @@ void perf_data_file_process_context::finish()
                                                         .process_id = entry.payload.process_id,
                                                         .name       = entry.payload.name,
                                                         .end_time   = {},
+                                                        .unique_id  = {},
                                                     });
-                threads_per_process_[entry.payload.process_id].emplace(id, entry.timestamp);
+                threads_per_process_id_[entry.payload.process_id].emplace(id, entry.timestamp);
             }
         }
     }
+
+    // Assign unique IDs to processes and threads.
+    unique_process_id next_process_id{.key = 0x100000000};
+    for(auto& [id, entries] : processes.all_entries())
+    {
+        process_info* prev = nullptr;
+        for(auto& entry : entries)
+        {
+            entry.payload.unique_id = next_process_id;
+            ++next_process_id.key;
+
+            unique_process_id_to_key_[*entry.payload.unique_id] = process_key{id, entry.timestamp};
+
+            if(prev != nullptr && prev->payload.end_time == std::nullopt)
+            {
+                prev->payload.end_time = entry.timestamp;
+            }
+
+            prev = &entry;
+        }
+    }
+    unique_thread_id next_thread_id{.key = 0x200000000};
+    for(auto& [id, entries] : threads.all_entries())
+    {
+        thread_info* prev = nullptr;
+        for(auto& entry : entries)
+        {
+            entry.payload.unique_id = next_thread_id;
+            ++next_thread_id.key;
+
+            unique_thread_id_to_key_[*entry.payload.unique_id] = thread_key{id, entry.timestamp};
+
+            if(prev != nullptr && prev->payload.end_time == std::nullopt)
+            {
+                prev->payload.end_time = entry.timestamp;
+            }
+
+            prev = &entry;
+        }
+    }
+
+    // Build threads per proccess map
+    for(const auto& [process_id, process_threads] : threads_per_process_id_)
+    {
+        for(const auto& thread_key : process_threads)
+        {
+            const auto* const process = processes.find_at(process_id, thread_key.time);
+            if(process == nullptr) continue;
+
+            const auto* const thread = threads.find_at(thread_key.id, thread_key.time);
+            if(thread == nullptr) continue;
+
+            threads_per_process_[*process->payload.unique_id].insert(*thread->payload.unique_id);
+        }
+    }
+
+    for(const auto& [id, thread_entries] : threads.all_entries())
+    {
+        const auto iter = samples_per_thread_id_.find(id);
+        if(iter == samples_per_thread_id_.end()) continue;
+        const auto& samples = iter->second;
+
+        for(const auto& thread_entry : thread_entries)
+        {
+            if(samples.last_sample_time < thread_entry.timestamp ||
+               (thread_entry.payload.end_time && samples.first_sample_time > *thread_entry.payload.end_time)) continue;
+
+            const auto* process = processes.find_at(thread_entry.payload.process_id, thread_entry.timestamp);
+            if(process == nullptr) continue;
+
+            const auto sampled_process_key = process_key{process->id, process->timestamp};
+
+            const auto first_sample_time = std::max(samples.first_sample_time, thread_entry.timestamp);
+            const auto last_sample_time  = thread_entry.payload.end_time ?
+                                               std::min(samples.last_sample_time, *thread_entry.payload.end_time) :
+                                               samples.last_sample_time;
+
+            auto proc_iter = sampled_processes_.find(sampled_process_key);
+            if(proc_iter == sampled_processes_.end())
+            {
+                sampled_processes_[sampled_process_key] = sampled_process_info{
+                    .process_id        = process->id,
+                    .process_timestamp = process->timestamp,
+                    .first_sample_time = first_sample_time,
+                    .last_sample_time  = last_sample_time};
+            }
+            else
+            {
+                proc_iter->second.first_sample_time = std::min(proc_iter->second.first_sample_time, first_sample_time);
+                proc_iter->second.last_sample_time  = std::max(proc_iter->second.last_sample_time, last_sample_time);
+            }
+        }
+    }
+}
+
+perf_data_file_process_context::process_key perf_data_file_process_context::id_to_key(unique_process_id id) const
+{
+    return unique_process_id_to_key_.at(id);
+}
+
+perf_data_file_process_context::thread_key perf_data_file_process_context::id_to_key(unique_thread_id id) const
+{
+    return unique_thread_id_to_key_.at(id);
 }
 
 template<typename T>
@@ -76,14 +183,18 @@ void perf_data_file_process_context::register_event()
 
 void perf_data_file_process_context::handle_event(const perf_data::parser::comm_event_view& event)
 {
-    const auto pid  = event.pid();
-    const auto tid  = event.tid();
+    const auto pid = event.pid();
+    const auto tid = event.tid();
+
+    assert(event.sample_id().time);
     const auto time = *event.sample_id().time;
+
     if(pid == tid)
     {
         process_names.insert(pid, time, process_data{
-                                            .name     = std::string(event.comm()),
-                                            .end_time = {},
+                                            .name      = std::string(event.comm()),
+                                            .end_time  = {},
+                                            .unique_id = {},
                                         });
     }
 
@@ -91,6 +202,7 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::comm_
                                        .process_id = pid,
                                        .name       = std::string(event.comm()),
                                        .end_time   = {},
+                                       .unique_id  = {},
                                    });
 }
 
@@ -109,13 +221,14 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::fork_
                                   .process_id = pid,
                                   .name       = {},
                                   .end_time   = {},
+                                  .unique_id  = {},
                               });
-    threads_per_process_[pid].emplace(tid, time);
+    threads_per_process_id_[pid].emplace(tid, time);
 }
 
 void perf_data_file_process_context::handle_event(const perf_data::parser::mmap2_event_view& event)
 {
-    auto& process_modules = modules_per_process[event.pid()];
+    auto& process_modules = modules_per_process_id_[event.pid()];
 
     std::optional<perf_data::build_id> build_id;
     if(event.has_build_id())
@@ -139,14 +252,15 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::mmap2
 
 void perf_data_file_process_context::handle_event(const perf_data::parser::sample_event& event)
 {
-    assert(event.pid);
-    assert(event.tid);
+    if(event.tid == std::nullopt ||
+       event.time == std::nullopt) return;
+
     assert(event.ip);
     assert(event.ips);
 
     const auto stack_index = stacks.insert(*event.ips);
 
-    auto& storage = samples_per_process[*event.pid];
+    auto& storage = samples_per_thread_id_[*event.tid];
 
     storage.first_sample_time = std::min(storage.first_sample_time, *event.time);
     storage.last_sample_time  = std::max(storage.last_sample_time, *event.time);
@@ -158,9 +272,28 @@ void perf_data_file_process_context::handle_event(const perf_data::parser::sampl
         .stack_index         = stack_index});
 }
 
-const std::unordered_map<perf_data_file_process_context::process_id_t, perf_data_file_process_context::process_samples_storage>& perf_data_file_process_context::get_samples_per_process() const
+const std::unordered_map<perf_data_file_process_context::process_key, perf_data_file_process_context::sampled_process_info>& perf_data_file_process_context::sampled_processes() const
 {
-    return samples_per_process;
+    return sampled_processes_;
+}
+
+std::span<const perf_data_file_process_context::sample_info> perf_data_file_process_context::thread_samples(os_tid_t thread_id, timestamp_t start_time, std::optional<timestamp_t> end_time) const
+{
+    auto iter = samples_per_thread_id_.find(thread_id);
+    if(iter == samples_per_thread_id_.end()) return {};
+
+    const auto& thread_samples = iter->second.samples;
+
+    const auto range_first_iter = std::ranges::lower_bound(thread_samples, start_time, std::less<>(), &sample_info::timestamp);
+    if(range_first_iter == thread_samples.end()) return {};
+
+    const auto range_end_iter = end_time != std::nullopt ?
+                                    std::ranges::upper_bound(thread_samples, *end_time, std::less<>(), &sample_info::timestamp) :
+                                    thread_samples.end();
+
+    if(range_first_iter > range_end_iter) return {};
+
+    return std::span(thread_samples).subspan(range_first_iter - thread_samples.begin(), range_end_iter - range_first_iter);
 }
 
 const perf_data_file_process_context::process_history& perf_data_file_process_context::get_processes() const
@@ -173,14 +306,14 @@ const perf_data_file_process_context::thread_history& perf_data_file_process_con
     return threads;
 }
 
-const std::set<std::pair<perf_data_file_process_context::thread_id_t, perf_data_file_process_context::timestamp_t>>& perf_data_file_process_context::get_process_threads(process_id_t process_id) const
+const std::set<unique_thread_id>& perf_data_file_process_context::get_process_threads(unique_process_id process_id) const
 {
     return threads_per_process_.at(process_id);
 }
 
-const module_map<perf_data_file_process_context::module_data>& perf_data_file_process_context::get_modules(process_id_t process_id) const
+const module_map<perf_data_file_process_context::module_data, perf_data_file_process_context::timestamp_t>& perf_data_file_process_context::get_modules(os_pid_t process_id) const
 {
-    return modules_per_process.at(process_id);
+    return modules_per_process_id_.at(process_id);
 }
 
 const std::vector<perf_data_file_process_context::instruction_pointer_t>& perf_data_file_process_context::stack(std::size_t stack_index) const

--- a/snail/analysis/detail/perf_data_file_process_context.hpp
+++ b/snail/analysis/detail/perf_data_file_process_context.hpp
@@ -7,6 +7,9 @@
 #include <snail/perf_data/build_id.hpp>
 #include <snail/perf_data/dispatching_event_observer.hpp>
 
+#include <snail/analysis/data/ids.hpp>
+
+#include <snail/analysis/detail/id_at.hpp>
 #include <snail/analysis/detail/module_map.hpp>
 #include <snail/analysis/detail/process_history.hpp>
 #include <snail/analysis/detail/stack_cache.hpp>
@@ -25,11 +28,15 @@ namespace snail::analysis::detail {
 class perf_data_file_process_context
 {
 public:
-    using process_id_t          = std::uint32_t;
-    using thread_id_t           = std::uint32_t;
+    using os_pid_t              = std::uint32_t;
+    using os_tid_t              = std::uint32_t;
     using timestamp_t           = std::uint64_t;
     using instruction_pointer_t = std::uint64_t;
 
+    using process_key = id_at<os_pid_t, timestamp_t>;
+    using thread_key  = id_at<os_tid_t, timestamp_t>;
+
+    struct sampled_process_info;
     struct sample_info;
 
     struct process_data
@@ -38,6 +45,8 @@ public:
 
         std::optional<timestamp_t> end_time;
 
+        std::optional<unique_process_id> unique_id;
+
         [[nodiscard]] friend bool operator==(const process_data& lhs, const process_data& rhs)
         {
             return lhs.name == rhs.name;
@@ -45,10 +54,12 @@ public:
     };
     struct thread_data
     {
-        process_id_t               process_id;
+        os_pid_t                   process_id;
         std::optional<std::string> name;
 
         std::optional<timestamp_t> end_time;
+
+        std::optional<unique_thread_id> unique_id;
 
         [[nodiscard]] friend bool operator==(const thread_data& lhs, const thread_data& rhs)
         {
@@ -71,8 +82,8 @@ public:
         }
     };
 
-    using process_history = detail::history<process_id_t, timestamp_t, process_data>;
-    using thread_history  = detail::history<thread_id_t, timestamp_t, thread_data>;
+    using process_history = detail::history<os_pid_t, timestamp_t, process_data>;
+    using thread_history  = detail::history<os_tid_t, timestamp_t, thread_data>;
 
     using process_info = process_history::entry;
     using thread_info  = thread_history::entry;
@@ -85,22 +96,20 @@ public:
 
     void finish();
 
-    struct process_samples_storage
-    {
-        timestamp_t              first_sample_time = std::numeric_limits<timestamp_t>::max();
-        timestamp_t              last_sample_time  = std::numeric_limits<timestamp_t>::min();
-        std::vector<sample_info> samples;
-    };
+    process_key id_to_key(unique_process_id id) const;
+    thread_key  id_to_key(unique_thread_id id) const;
 
-    const std::unordered_map<process_id_t, process_samples_storage>& get_samples_per_process() const;
+    const std::unordered_map<process_key, sampled_process_info>& sampled_processes() const;
 
     const process_history& get_processes() const;
 
     const thread_history& get_threads() const;
 
-    const std::set<std::pair<thread_id_t, timestamp_t>>& get_process_threads(process_id_t process_id) const;
+    const std::set<unique_thread_id>& get_process_threads(unique_process_id process_id) const;
 
-    const module_map<module_data>& get_modules(process_id_t process_id) const;
+    const module_map<module_data, timestamp_t>& get_modules(os_pid_t process_id) const;
+
+    std::span<const sample_info> thread_samples(os_tid_t thread_id, timestamp_t start_time, std::optional<timestamp_t> end_time) const;
 
     const std::vector<instruction_pointer_t>& stack(std::size_t stack_index) const;
 
@@ -121,18 +130,42 @@ private:
     process_history processes;
     thread_history  threads;
 
-    std::unordered_map<process_id_t, std::set<std::pair<thread_id_t, timestamp_t>>> threads_per_process_;
+    std::unordered_map<os_pid_t, std::set<thread_key>> threads_per_process_id_;
 
-    std::unordered_map<process_id_t, module_map<module_data>> modules_per_process;
+    std::unordered_map<unique_process_id, std::set<unique_thread_id>> threads_per_process_;
 
-    std::unordered_map<process_id_t, process_samples_storage> samples_per_process;
+    std::unordered_map<unique_process_id, process_key> unique_process_id_to_key_;
+    std::unordered_map<unique_thread_id, thread_key>   unique_thread_id_to_key_;
+
+    std::unordered_map<os_pid_t, module_map<module_data, timestamp_t>> modules_per_process_id_;
+
+    struct samples_storage
+    {
+        timestamp_t              first_sample_time = std::numeric_limits<timestamp_t>::max();
+        timestamp_t              last_sample_time  = std::numeric_limits<timestamp_t>::min();
+        std::vector<sample_info> samples;
+    };
+
+    std::unordered_map<os_tid_t, samples_storage> samples_per_thread_id_;
+
+    std::unordered_map<process_key, sampled_process_info> sampled_processes_;
 
     stack_cache stacks;
 };
 
+struct perf_data_file_process_context::sampled_process_info
+{
+    os_pid_t process_id;
+
+    timestamp_t process_timestamp;
+
+    timestamp_t first_sample_time;
+    timestamp_t last_sample_time;
+};
+
 struct perf_data_file_process_context::sample_info
 {
-    thread_id_t thread_id;
+    os_tid_t thread_id;
 
     timestamp_t timestamp;
 

--- a/snail/analysis/detail/process_history.hpp
+++ b/snail/analysis/detail/process_history.hpp
@@ -29,6 +29,10 @@ public:
     {
         return entries_by_id;
     }
+    [[nodiscard]] std::unordered_map<Id, std::vector<entry>>& all_entries()
+    {
+        return entries_by_id;
+    }
 
     [[nodiscard]] std::size_t size() const
     {

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -323,6 +323,8 @@ common::generator<const sample_data&> etl_data_provider::samples(unique_process_
 {
     if(process_context_ == nullptr) co_return;
 
+    if(filter.excluded_processes.contains(process_id)) co_return;
+
     assert(symbol_resolver_ != nullptr);
 
     const auto& process_context = *process_context_;
@@ -352,6 +354,8 @@ common::generator<const sample_data&> etl_data_provider::samples(unique_process_
 
     for(const auto& thread_id : threads)
     {
+        if(filter.excluded_threads.contains(thread_id)) continue;
+
         const auto        thread_key = process_context.id_to_key(thread_id);
         const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
         if(thread == nullptr) continue;
@@ -444,6 +448,8 @@ std::size_t etl_data_provider::count_samples(unique_process_id    process_id,
 {
     if(process_context_ == nullptr) return 0;
 
+    if(filter.excluded_processes.contains(process_id)) return 0;
+
     // TODO: remove code duplication
 
     assert(symbol_resolver_ != nullptr);
@@ -461,6 +467,8 @@ std::size_t etl_data_provider::count_samples(unique_process_id    process_id,
     std::size_t total_samples_count = 0;
     for(const auto& thread_id : threads)
     {
+        if(filter.excluded_threads.contains(thread_id)) continue;
+
         const auto        thread_key = process_context.id_to_key(thread_id);
         const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
         if(thread == nullptr) continue;

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -191,6 +191,8 @@ void etl_data_provider::process(const std::filesystem::path& file_path)
         }
     }
 
+    pointer_size_ = file.header().pointer_size;
+
     const auto runtime = file.header().end_time - file.header().start_time;
 
     session_start_qpc_ticks_ = file.header().start_time_qpc_ticks;
@@ -295,7 +297,8 @@ common::generator<analysis::thread_info> etl_data_provider::threads_info(common:
     }
 }
 
-common::generator<const sample_data&> etl_data_provider::samples(common::process_id_t process_id) const
+common::generator<const sample_data&> etl_data_provider::samples(common::process_id_t process_id,
+                                                                 const sample_filter& filter) const
 {
     if(process_context_ == nullptr) co_return;
 

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -79,7 +79,7 @@ struct etl_sample_data : public sample_data
         }
         if(kernel_stack != nullptr)
         {
-            static constexpr detail::etl_file_process_context::process_id_t kernel_process_id = 0;
+            static constexpr detail::etl_file_process_context::os_pid_t kernel_process_id = 0;
             for(const auto instruction_pointer : std::views::reverse(*kernel_stack))
             {
                 auto [module, load_timestamp] = context->get_modules(kernel_process_id).find(instruction_pointer, kernel_timestamp);
@@ -116,9 +116,9 @@ struct etl_sample_data : public sample_data
     detail::etl_file_process_context::timestamp_t                               kernel_timestamp;
     detail::etl_file_process_context::timestamp_t                               user_timestamp;
 
-    detail::etl_file_process_context::process_id_t process_id;
-    detail::pdb_resolver*                          resolver;
-    detail::etl_file_process_context*              context;
+    detail::etl_file_process_context::os_pid_t process_id;
+    detail::pdb_resolver*                      resolver;
+    detail::etl_file_process_context*          context;
 
     detail::etl_file_process_context::timestamp_t sample_timestamp;
     std::uint64_t                                 session_start_qpc_ticks;
@@ -144,8 +144,8 @@ std::string win_architecture_to_str(std::uint16_t arch)
 
 struct next_sample_priority_info
 {
-    common::timestamp_t next_sample_time;
-    std::size_t         thread_index;
+    detail::etl_file_process_context::timestamp_t next_sample_time;
+    std::size_t                                   thread_index;
 
     bool operator<(const next_sample_priority_info& other) const
     {
@@ -189,17 +189,22 @@ void etl_data_provider::process(const std::filesystem::path& file_path)
 
     std::size_t total_sample_count = 0;
     std::size_t total_thread_count = 0;
-    for(const auto& [process_id, profiler_process_info] : process_context_->profiler_processes())
+    for(const auto& [process_key, profiler_process_info] : process_context_->profiler_processes())
     {
-        const auto& threads = process_context_->get_process_threads(process_id);
+        const auto* const process = process_context_->get_processes().find_at(process_key.id, process_key.time);
+        if(process == nullptr) continue;
+
+        assert(process->payload.unique_id);
+        const auto& threads = process_context_->get_process_threads(*process->payload.unique_id);
         total_thread_count += std::ranges::size(threads);
 
-        for(const auto& [thread_id, thread_start_timestamp] : threads)
+        for(const auto& thread_id : threads)
         {
-            const auto* const thread = process_context_->get_threads().find_at(thread_id, thread_start_timestamp);
+            const auto        thread_key = process_context_->id_to_key(thread_id);
+            const auto* const thread     = process_context_->get_threads().find_at(thread_key.id, thread_key.time);
             if(thread == nullptr) continue;
 
-            const auto samples = process_context_->thread_samples(thread_id, thread->timestamp, thread->payload.end_time);
+            const auto samples = process_context_->thread_samples(thread_key.id, thread->timestamp, thread->payload.end_time);
             total_sample_count += std::ranges::size(samples);
         }
     }
@@ -257,29 +262,32 @@ const analysis::system_info& etl_data_provider::system_info() const
     return *system_info_;
 }
 
-common::generator<common::process_id_t> etl_data_provider::sampling_processes() const
+common::generator<unique_process_id> etl_data_provider::sampling_processes() const
 {
     if(process_context_ == nullptr) co_return;
 
     const auto& process_context = *process_context_;
 
-    for(const auto& [process_id, profiler_process_info] : process_context.profiler_processes())
+    for(const auto& [process_key, profiler_process_info] : process_context.profiler_processes())
     {
-        co_yield common::process_id_t(process_id);
+        const auto* const process = process_context_->get_processes().find_at(process_key.id, process_key.time);
+        if(process == nullptr || process->payload.unique_id == std::nullopt) continue;
+
+        co_yield unique_process_id(*process->payload.unique_id);
     }
 }
 
-analysis::process_info etl_data_provider::process_info(common::process_id_t process_id) const
+analysis::process_info etl_data_provider::process_info(unique_process_id process_id) const
 {
     assert(process_context_ != nullptr);
 
-    const auto& profiler_process_info = process_context_->profiler_processes().at(process_id);
-
-    const auto* const process = process_context_->get_processes().find_at(process_id, profiler_process_info.start_timestamp);
-    if(process == nullptr) throw std::runtime_error(std::format("Invalid process {}", process_id));
+    const auto        process_key = process_context_->id_to_key(process_id);
+    const auto* const process     = process_context_->get_processes().find_at(process_key.id, process_key.time);
+    if(process == nullptr) throw std::runtime_error(std::format("Invalid process {} @{}", process_key.id, process_key.time));
 
     return analysis::process_info{
-        .id         = process_id,
+        .unique_id  = process_id,
+        .os_id      = process->id,
         .name       = process->payload.image_filename,
         .start_time = from_relative_qpc_ticks<std::chrono::nanoseconds>(process->timestamp, session_start_qpc_ticks_, qpc_frequency_),
         .end_time   = process->payload.end_time ?
@@ -287,21 +295,21 @@ analysis::process_info etl_data_provider::process_info(common::process_id_t proc
                           from_relative_qpc_ticks<std::chrono::nanoseconds>(session_end_qpc_ticks_, session_start_qpc_ticks_, qpc_frequency_)};
 }
 
-common::generator<analysis::thread_info> etl_data_provider::threads_info(common::process_id_t process_id) const
+common::generator<analysis::thread_info> etl_data_provider::threads_info(unique_process_id process_id) const
 {
     if(process_context_ == nullptr) co_return;
 
     const auto& process = process_info(process_id);
 
-    for(const auto& [thread_id, time] : process_context_->get_process_threads(process_id))
+    for(const auto& thread_id : process_context_->get_process_threads(process_id))
     {
-        const auto* const thread = process_context_->get_threads().find_at(thread_id, time);
-
-        assert(thread != nullptr);
-        if(thread == nullptr) continue; // fault tolerance in release mode
+        const auto        thread_key = process_context_->id_to_key(thread_id);
+        const auto* const thread     = process_context_->get_threads().find_at(thread_key.id, thread_key.time);
+        if(thread == nullptr) continue;
 
         co_yield analysis::thread_info{
-            .id         = thread->id,
+            .unique_id  = thread_id,
+            .os_id      = thread->id,
             .name       = std::nullopt,
             .start_time = from_relative_qpc_ticks<std::chrono::nanoseconds>(thread->timestamp, session_start_qpc_ticks_, qpc_frequency_),
             .end_time   = thread->payload.end_time ?
@@ -310,7 +318,7 @@ common::generator<analysis::thread_info> etl_data_provider::threads_info(common:
     }
 }
 
-common::generator<const sample_data&> etl_data_provider::samples(common::process_id_t process_id,
+common::generator<const sample_data&> etl_data_provider::samples(unique_process_id    process_id,
                                                                  const sample_filter& filter) const
 {
     if(process_context_ == nullptr) co_return;
@@ -319,24 +327,21 @@ common::generator<const sample_data&> etl_data_provider::samples(common::process
 
     const auto& process_context = *process_context_;
 
-    std::unordered_map<
-        detail::etl_file_process_context::thread_id_t,
-        std::vector<const detail::etl_file_process_context::sample_info*>>
-        remembered_kernel_samples;
+    const auto process_key = process_context_->id_to_key(process_id);
 
     etl_sample_data current_sample_data;
 
-    current_sample_data.process_id              = process_id;
+    current_sample_data.process_id              = process_key.id;
     current_sample_data.context                 = process_context_.get();
     current_sample_data.resolver                = symbol_resolver_.get();
     current_sample_data.session_start_qpc_ticks = session_start_qpc_ticks_;
     current_sample_data.qpc_frequency           = qpc_frequency_;
 
     const auto filter_min_timestamp = filter.min_time == std::nullopt ? std::nullopt :
-                                                                        std::make_optional(static_cast<common::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.min_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
+                                                                        std::make_optional(static_cast<detail::etl_file_process_context::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.min_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
 
     const auto filter_max_timestamp = filter.max_time == std::nullopt ? std::nullopt :
-                                                                        std::make_optional(static_cast<common::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.max_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
+                                                                        std::make_optional(static_cast<detail::etl_file_process_context::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.max_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
 
     const auto& threads = process_context.get_process_threads(process_id);
 
@@ -345,22 +350,23 @@ common::generator<const sample_data&> etl_data_provider::samples(common::process
     std::vector<thread_sample_data> threads_samples;
     threads_samples.reserve(threads.size());
 
-    for(const auto& [thread_id, thread_start_timestamp] : threads)
+    for(const auto& thread_id : threads)
     {
-        const auto* const thread = process_context.get_threads().find_at(thread_id, thread_start_timestamp);
+        const auto        thread_key = process_context.id_to_key(thread_id);
+        const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
         if(thread == nullptr) continue;
 
-        const auto& sample_min_time = filter_min_timestamp ?
-                                          std::max(*filter_min_timestamp, thread->timestamp) :
-                                          thread->timestamp;
+        const auto sample_min_time = filter_min_timestamp ?
+                                         std::max(*filter_min_timestamp, thread->timestamp) :
+                                         thread->timestamp;
 
-        const auto& sample_max_time = filter_max_timestamp ?
-                                          (thread->payload.end_time ?
-                                               std::min(*filter_max_timestamp, *thread->payload.end_time) :
-                                               std::optional<common::timestamp_t>{}) :
-                                          thread->payload.end_time;
+        const auto sample_max_time = filter_max_timestamp ?
+                                         (thread->payload.end_time ?
+                                              std::min(*filter_max_timestamp, *thread->payload.end_time) :
+                                              *filter_max_timestamp) :
+                                         thread->payload.end_time;
 
-        const auto samples = process_context.thread_samples(thread_id, sample_min_time, sample_max_time);
+        const auto samples = process_context.thread_samples(thread_key.id, sample_min_time, sample_max_time);
 
         if(samples.empty()) continue;
 

--- a/snail/analysis/etl_data_provider.cpp
+++ b/snail/analysis/etl_data_provider.cpp
@@ -438,3 +438,44 @@ common::generator<const sample_data&> etl_data_provider::samples(unique_process_
         }
     }
 }
+
+std::size_t etl_data_provider::count_samples(unique_process_id    process_id,
+                                             const sample_filter& filter) const
+{
+    if(process_context_ == nullptr) return 0;
+
+    // TODO: remove code duplication
+
+    assert(symbol_resolver_ != nullptr);
+
+    const auto& process_context = *process_context_;
+
+    const auto filter_min_timestamp = filter.min_time == std::nullopt ? std::nullopt :
+                                                                        std::make_optional(static_cast<detail::etl_file_process_context::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.min_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
+
+    const auto filter_max_timestamp = filter.max_time == std::nullopt ? std::nullopt :
+                                                                        std::make_optional(static_cast<detail::etl_file_process_context::timestamp_t>(session_start_qpc_ticks_ + std::max(to_qpc_ticks(*filter.max_time, qpc_frequency_), std::chrono::nanoseconds::rep(0))));
+
+    const auto& threads = process_context.get_process_threads(process_id);
+
+    std::size_t total_samples_count = 0;
+    for(const auto& thread_id : threads)
+    {
+        const auto        thread_key = process_context.id_to_key(thread_id);
+        const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
+        if(thread == nullptr) continue;
+
+        const auto sample_min_time = filter_min_timestamp ?
+                                         std::max(*filter_min_timestamp, thread->timestamp) :
+                                         thread->timestamp;
+
+        const auto sample_max_time = filter_max_timestamp ?
+                                         (thread->payload.end_time ?
+                                              std::min(*filter_max_timestamp, *thread->payload.end_time) :
+                                              *filter_max_timestamp) :
+                                         thread->payload.end_time;
+
+        total_samples_count += process_context.thread_samples(thread_key.id, sample_min_time, sample_max_time).size();
+    }
+    return total_samples_count;
+}

--- a/snail/analysis/etl_data_provider.hpp
+++ b/snail/analysis/etl_data_provider.hpp
@@ -38,7 +38,8 @@ public:
 
     virtual common::generator<analysis::thread_info> threads_info(common::process_id_t process_id) const override;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id) const override;
+    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+                                                          const sample_filter& filter) const override;
 
 private:
     std::unique_ptr<detail::etl_file_process_context> process_context_;

--- a/snail/analysis/etl_data_provider.hpp
+++ b/snail/analysis/etl_data_provider.hpp
@@ -51,6 +51,7 @@ private:
     std::uint64_t session_start_qpc_ticks_;
     std::uint64_t session_end_qpc_ticks_;
     std::uint64_t qpc_frequency_;
+    std::uint32_t pointer_size_;
 };
 
 } // namespace snail::analysis

--- a/snail/analysis/etl_data_provider.hpp
+++ b/snail/analysis/etl_data_provider.hpp
@@ -32,13 +32,13 @@ public:
 
     virtual const analysis::system_info& system_info() const override;
 
-    virtual common::generator<common::process_id_t> sampling_processes() const override;
+    virtual common::generator<unique_process_id> sampling_processes() const override;
 
-    virtual analysis::process_info process_info(common::process_id_t process_id) const override;
+    virtual analysis::process_info process_info(unique_process_id process_id) const override;
 
-    virtual common::generator<analysis::thread_info> threads_info(common::process_id_t process_id) const override;
+    virtual common::generator<analysis::thread_info> threads_info(unique_process_id process_id) const override;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+    virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter) const override;
 
 private:

--- a/snail/analysis/etl_data_provider.hpp
+++ b/snail/analysis/etl_data_provider.hpp
@@ -41,6 +41,9 @@ public:
     virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter) const override;
 
+    virtual std::size_t count_samples(unique_process_id    process_id,
+                                      const sample_filter& filter) const override;
+
 private:
     std::unique_ptr<detail::etl_file_process_context> process_context_;
     std::unique_ptr<detail::pdb_resolver>             symbol_resolver_;

--- a/snail/analysis/options.hpp
+++ b/snail/analysis/options.hpp
@@ -4,8 +4,11 @@
 #include <filesystem>
 #include <optional>
 #include <regex>
+#include <set>
 #include <string>
 #include <vector>
+
+#include <snail/analysis/data/ids.hpp>
 
 namespace snail::analysis {
 
@@ -59,6 +62,9 @@ struct sample_filter
 {
     std::optional<std::chrono::nanoseconds> min_time;
     std::optional<std::chrono::nanoseconds> max_time;
+
+    std::set<unique_process_id> excluded_processes;
+    std::set<unique_thread_id>  excluded_threads;
 
     bool operator==(const sample_filter& other) const = default;
 };

--- a/snail/analysis/options.hpp
+++ b/snail/analysis/options.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <chrono>
 #include <filesystem>
+#include <optional>
 #include <regex>
 #include <string>
 #include <vector>
+
+#include <snail/common/types.hpp>
 
 namespace snail::analysis {
 
@@ -51,6 +55,14 @@ struct options
     dwarf_symbol_find_options dwarf_find_options;
 
     filter_options filter;
+};
+
+struct sample_filter
+{
+    std::optional<std::chrono::nanoseconds> min_time;
+    std::optional<std::chrono::nanoseconds> max_time;
+
+    bool operator==(const sample_filter& other) const = default;
 };
 
 } // namespace snail::analysis

--- a/snail/analysis/options.hpp
+++ b/snail/analysis/options.hpp
@@ -7,8 +7,6 @@
 #include <string>
 #include <vector>
 
-#include <snail/common/types.hpp>
-
 namespace snail::analysis {
 
 enum class filter_mode

--- a/snail/analysis/perf_data_data_provider.cpp
+++ b/snail/analysis/perf_data_data_provider.cpp
@@ -249,7 +249,8 @@ common::generator<analysis::thread_info> perf_data_data_provider::threads_info(c
     }
 }
 
-common::generator<const sample_data&> perf_data_data_provider::samples(common::process_id_t process_id) const
+common::generator<const sample_data&> perf_data_data_provider::samples(common::process_id_t process_id,
+                                                                       const sample_filter& filter) const
 {
     if(process_context_ == nullptr) co_return;
 

--- a/snail/analysis/perf_data_data_provider.cpp
+++ b/snail/analysis/perf_data_data_provider.cpp
@@ -299,6 +299,8 @@ common::generator<const sample_data&> perf_data_data_provider::samples(unique_pr
 {
     if(process_context_ == nullptr) co_return;
 
+    if(filter.excluded_processes.contains(process_id)) co_return;
+
     assert(symbol_resolver_ != nullptr);
 
     const auto& process_context = *process_context_;
@@ -328,6 +330,8 @@ common::generator<const sample_data&> perf_data_data_provider::samples(unique_pr
 
     for(const auto& thread_id : threads)
     {
+        if(filter.excluded_threads.contains(thread_id)) continue;
+
         const auto        thread_key = process_context.id_to_key(thread_id);
         const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
         if(thread == nullptr) continue;
@@ -401,6 +405,8 @@ std::size_t perf_data_data_provider::count_samples(unique_process_id    process_
 {
     if(process_context_ == nullptr) return 0;
 
+    if(filter.excluded_processes.contains(process_id)) return 0;
+
     // TODO: remove code duplication
 
     assert(symbol_resolver_ != nullptr);
@@ -418,6 +424,8 @@ std::size_t perf_data_data_provider::count_samples(unique_process_id    process_
     std::size_t total_samples_count = 0;
     for(const auto& thread_id : threads)
     {
+        if(filter.excluded_threads.contains(thread_id)) continue;
+
         const auto        thread_key = process_context.id_to_key(thread_id);
         const auto* const thread     = process_context.get_threads().find_at(thread_key.id, thread_key.time);
         if(thread == nullptr) continue;

--- a/snail/analysis/perf_data_data_provider.hpp
+++ b/snail/analysis/perf_data_data_provider.hpp
@@ -35,13 +35,13 @@ public:
 
     virtual const analysis::system_info& system_info() const override;
 
-    virtual common::generator<common::process_id_t> sampling_processes() const override;
+    virtual common::generator<unique_process_id> sampling_processes() const override;
 
-    virtual analysis::process_info process_info(common::process_id_t process_id) const override;
+    virtual analysis::process_info process_info(unique_process_id process_id) const override;
 
-    virtual common::generator<analysis::thread_info> threads_info(common::process_id_t process_id) const override;
+    virtual common::generator<analysis::thread_info> threads_info(unique_process_id process_id) const override;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+    virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter) const override;
 
 private:
@@ -52,8 +52,8 @@ private:
     std::optional<analysis::session_info>                               session_info_;
     std::optional<analysis::system_info>                                system_info_;
 
-    common::timestamp_t session_start_time_;
-    common::timestamp_t session_end_time_;
+    std::uint64_t session_start_time_;
+    std::uint64_t session_end_time_;
 };
 
 } // namespace snail::analysis

--- a/snail/analysis/perf_data_data_provider.hpp
+++ b/snail/analysis/perf_data_data_provider.hpp
@@ -44,6 +44,9 @@ public:
     virtual common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                           const sample_filter& filter) const override;
 
+    virtual std::size_t count_samples(unique_process_id    process_id,
+                                      const sample_filter& filter) const override;
+
 private:
     std::unique_ptr<detail::perf_data_file_process_context> process_context_;
     std::unique_ptr<detail::dwarf_resolver>                 symbol_resolver_;

--- a/snail/analysis/perf_data_data_provider.hpp
+++ b/snail/analysis/perf_data_data_provider.hpp
@@ -41,7 +41,8 @@ public:
 
     virtual common::generator<analysis::thread_info> threads_info(common::process_id_t process_id) const override;
 
-    virtual common::generator<const sample_data&> samples(common::process_id_t process_id) const override;
+    virtual common::generator<const sample_data&> samples(common::process_id_t process_id,
+                                                          const sample_filter& filter) const override;
 
 private:
     std::unique_ptr<detail::perf_data_file_process_context> process_context_;

--- a/snail/common/types.hpp
+++ b/snail/common/types.hpp
@@ -4,12 +4,6 @@
 
 namespace snail::common {
 
-using process_id_t = std::uint32_t;
-
-using thread_id_t = std::uint32_t;
-
 using instruction_pointer_t = std::uint64_t;
-
-using timestamp_t = std::uint64_t;
 
 } // namespace snail::common

--- a/snail/server/requests/protocol.hpp
+++ b/snail/server/requests/protocol.hpp
@@ -223,10 +223,10 @@ struct retrieve_call_tree_hot_path_request
     static constexpr std::string_view name = "retrieveCallTreeHotPath";
 
     static constexpr auto parameters = std::tuple(
-        snail::jsonrpc::detail::request_parameter<snail::common::process_id_t>{"processId"},
+        snail::jsonrpc::detail::request_parameter<std::uint64_t>{"processKey"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
-    const snail::common::process_id_t& process_id() const
+    const std::uint64_t& process_key() const
     {
         return std::get<0>(data_);
     }
@@ -243,7 +243,7 @@ struct retrieve_call_tree_hot_path_request
 
 private:
     std::tuple<
-        snail::common::process_id_t,
+        std::uint64_t,
         std::size_t>
         data_;
 };
@@ -260,7 +260,7 @@ struct retrieve_functions_page_request
     static constexpr auto parameters = std::tuple(
         snail::jsonrpc::detail::request_parameter<std::size_t>{"pageSize"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"pageIndex"},
-        snail::jsonrpc::detail::request_parameter<snail::common::process_id_t>{"processId"},
+        snail::jsonrpc::detail::request_parameter<std::uint64_t>{"processKey"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
     const std::size_t& page_size() const
@@ -273,7 +273,7 @@ struct retrieve_functions_page_request
         return std::get<1>(data_);
     }
 
-    const snail::common::process_id_t& process_id() const
+    const std::uint64_t& process_key() const
     {
         return std::get<2>(data_);
     }
@@ -292,7 +292,7 @@ private:
     std::tuple<
         std::size_t,
         std::size_t,
-        snail::common::process_id_t,
+        std::uint64_t,
         std::size_t>
         data_;
 };
@@ -308,7 +308,7 @@ struct expand_call_tree_node_request
 
     static constexpr auto parameters = std::tuple(
         snail::jsonrpc::detail::request_parameter<std::size_t>{"nodeId"},
-        snail::jsonrpc::detail::request_parameter<snail::common::process_id_t>{"processId"},
+        snail::jsonrpc::detail::request_parameter<std::uint64_t>{"processKey"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
     const std::size_t& node_id() const
@@ -316,7 +316,7 @@ struct expand_call_tree_node_request
         return std::get<0>(data_);
     }
 
-    const snail::common::process_id_t& process_id() const
+    const std::uint64_t& process_key() const
     {
         return std::get<1>(data_);
     }
@@ -334,7 +334,7 @@ struct expand_call_tree_node_request
 private:
     std::tuple<
         std::size_t,
-        snail::common::process_id_t,
+        std::uint64_t,
         std::size_t>
         data_;
 };
@@ -351,7 +351,7 @@ struct retrieve_callers_callees_request
     static constexpr auto parameters = std::tuple(
         snail::jsonrpc::detail::request_parameter<std::size_t>{"maxEntries"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"functionId"},
-        snail::jsonrpc::detail::request_parameter<snail::common::process_id_t>{"processId"},
+        snail::jsonrpc::detail::request_parameter<std::uint64_t>{"processKey"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
     const std::size_t& max_entries() const
@@ -364,7 +364,7 @@ struct retrieve_callers_callees_request
         return std::get<1>(data_);
     }
 
-    const snail::common::process_id_t& process_id() const
+    const std::uint64_t& process_key() const
     {
         return std::get<2>(data_);
     }
@@ -383,7 +383,7 @@ private:
     std::tuple<
         std::size_t,
         std::size_t,
-        snail::common::process_id_t,
+        std::uint64_t,
         std::size_t>
         data_;
 };
@@ -399,7 +399,7 @@ struct retrieve_line_info_request
 
     static constexpr auto parameters = std::tuple(
         snail::jsonrpc::detail::request_parameter<std::size_t>{"functionId"},
-        snail::jsonrpc::detail::request_parameter<snail::common::process_id_t>{"processId"},
+        snail::jsonrpc::detail::request_parameter<std::uint64_t>{"processKey"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
     const std::size_t& function_id() const
@@ -407,7 +407,7 @@ struct retrieve_line_info_request
         return std::get<0>(data_);
     }
 
-    const snail::common::process_id_t& process_id() const
+    const std::uint64_t& process_key() const
     {
         return std::get<1>(data_);
     }
@@ -425,7 +425,7 @@ struct retrieve_line_info_request
 private:
     std::tuple<
         std::size_t,
-        snail::common::process_id_t,
+        std::uint64_t,
         std::size_t>
         data_;
 };

--- a/snail/server/requests/protocol.hpp
+++ b/snail/server/requests/protocol.hpp
@@ -435,6 +435,49 @@ struct is_request<retrieve_line_info_request> : std::true_type
 {};
 } // namespace snail::jsonrpc::detail
 
+struct set_sample_filters_request
+{
+    static constexpr std::string_view name = "setSampleFilters";
+
+    static constexpr auto parameters = std::tuple(
+        snail::jsonrpc::detail::request_parameter<std::optional<std::size_t>>{"minTime"},
+        snail::jsonrpc::detail::request_parameter<std::optional<std::size_t>>{"maxTime"},
+        snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
+
+    // In nanoseconds since session start.
+    const std::optional<std::size_t>& min_time() const
+    {
+        return std::get<0>(data_);
+    }
+    // In nanoseconds since session start.
+    const std::optional<std::size_t>& max_time() const
+    {
+        return std::get<1>(data_);
+    }
+    // The id of the document to perform the operation on.
+    // This should be an id that resulted from a call to `readDocument`.
+    const std::size_t& document_id() const
+    {
+        return std::get<2>(data_);
+    }
+
+    template<typename RequestType>
+        requires snail::jsonrpc::detail::is_request_v<RequestType>
+    friend RequestType snail::jsonrpc::detail::unpack_request(const nlohmann::json& raw_data);
+
+private:
+    std::tuple<
+        std::optional<std::size_t>,
+        std::optional<std::size_t>,
+        std::size_t>
+        data_;
+};
+namespace snail::jsonrpc::detail {
+template<>
+struct is_request<set_sample_filters_request> : std::true_type
+{};
+} // namespace snail::jsonrpc::detail
+
 struct close_document_request
 {
     static constexpr std::string_view name = "closeDocument";

--- a/snail/server/requests/protocol.hpp
+++ b/snail/server/requests/protocol.hpp
@@ -442,6 +442,8 @@ struct set_sample_filters_request
     static constexpr auto parameters = std::tuple(
         snail::jsonrpc::detail::request_parameter<std::optional<std::size_t>>{"minTime"},
         snail::jsonrpc::detail::request_parameter<std::optional<std::size_t>>{"maxTime"},
+        snail::jsonrpc::detail::request_parameter<std::vector<std::uint64_t>>{"excludedProcesses"},
+        snail::jsonrpc::detail::request_parameter<std::vector<std::uint64_t>>{"excludedThreads"},
         snail::jsonrpc::detail::request_parameter<std::size_t>{"documentId"});
 
     // In nanoseconds since session start.
@@ -454,11 +456,21 @@ struct set_sample_filters_request
     {
         return std::get<1>(data_);
     }
+
+    const std::vector<std::uint64_t>& excluded_processes() const
+    {
+        return std::get<2>(data_);
+    }
+
+    const std::vector<std::uint64_t>& excluded_threads() const
+    {
+        return std::get<3>(data_);
+    }
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
     const std::size_t& document_id() const
     {
-        return std::get<2>(data_);
+        return std::get<4>(data_);
     }
 
     template<typename RequestType>
@@ -469,6 +481,8 @@ private:
     std::tuple<
         std::optional<std::size_t>,
         std::optional<std::size_t>,
+        std::vector<std::uint64_t>,
+        std::vector<std::uint64_t>,
         std::size_t>
         data_;
 };

--- a/snail/server/requests/requests.cpp
+++ b/snail/server/requests/requests.cpp
@@ -28,7 +28,7 @@ namespace {
 template<std::integral T, std::integral U>
 double make_percent(T value, U max_value)
 {
-    return static_cast<double>(value) * 100.0 / static_cast<double>(max_value);
+    return max_value == 0 ? 0.0 : (static_cast<double>(value) * 100.0 / static_cast<double>(max_value));
 }
 
 const analysis::call_tree_node* get_top_child(const analysis::stacks_analysis& stacks_analysis,

--- a/snail/server/requests/requests.cpp
+++ b/snail/server/requests/requests.cpp
@@ -255,6 +255,15 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
             if(request.min_time()) filter.min_time = std::chrono::nanoseconds(static_cast<std::chrono::nanoseconds::rep>(*request.min_time()));
             if(request.max_time()) filter.max_time = std::chrono::nanoseconds(static_cast<std::chrono::nanoseconds::rep>(*request.max_time()));
 
+            for(const auto thread_key : request.excluded_threads())
+            {
+                filter.excluded_threads.insert(analysis::unique_thread_id{thread_key});
+            }
+            for(const auto process_key : request.excluded_processes())
+            {
+                filter.excluded_processes.insert(analysis::unique_process_id{process_key});
+            }
+
             storage.apply_document_filter({request.document_id()}, std::move(filter));
 
             return nullptr;

--- a/snail/server/requests/requests.cpp
+++ b/snail/server/requests/requests.cpp
@@ -246,6 +246,19 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
             storage.close_document({request.document_id()});
         });
 
+    server.register_request<set_sample_filters_request>(
+        [&](const set_sample_filters_request& request) -> nlohmann::json
+        {
+            analysis::sample_filter filter;
+
+            if(request.min_time()) filter.min_time = std::chrono::nanoseconds(static_cast<std::chrono::nanoseconds::rep>(*request.min_time()));
+            if(request.max_time()) filter.max_time = std::chrono::nanoseconds(static_cast<std::chrono::nanoseconds::rep>(*request.max_time()));
+
+            storage.apply_document_filter({request.document_id()}, std::move(filter));
+
+            return nullptr;
+        });
+
     server.register_request<retrieve_session_info_request>(
         [&](const retrieve_session_info_request& request) -> nlohmann::json
         {

--- a/snail/server/requests/requests.cpp
+++ b/snail/server/requests/requests.cpp
@@ -371,7 +371,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
                                   return lhs.function->hits.self > rhs.function->hits.self;
                               });
 
-            const auto total_hits = data_provider.session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             auto json_functions = nlohmann::json::array();
             for(const auto& entry : intermediate_functions | std::views::take(request.count()))
@@ -405,7 +405,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
 
             const auto& process_info = data_provider.process_info({request.process_key()});
 
-            const auto total_hits = data_provider.session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             auto json_functions = nlohmann::json::array();
             // if(sort_order == direction::descending)
@@ -436,7 +436,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
             const auto& data_provider = storage.get_data({request.document_id()});
             const auto& process       = data_provider.process_info({request.process_key()});
 
-            const auto total_hits = data_provider.session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             const auto root_name = std::format("{} (PID: {})", process.name, process.os_id);
 
@@ -480,7 +480,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
         {
             const auto& stacks_analysis = storage.get_stacks_analysis({request.document_id()}, {request.process_key()});
 
-            const auto total_hits = storage.get_data({request.document_id()}).session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             const auto& current_node = stacks_analysis.get_call_tree_node(request.node_id());
 
@@ -501,7 +501,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
 
             const auto max_entries = request.max_entries() > 0 ? request.max_entries() : 1;
 
-            const auto total_hits = data_provider.session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             const auto& function = stacks_analysis.get_function(request.function_id());
 
@@ -602,7 +602,7 @@ void snail::server::register_all(snail::jsonrpc::server& server, snail::server::
                 return nullptr;
             }
 
-            const auto total_hits = storage.get_data({request.document_id()}).session_info().number_of_samples; // TODO: use filtered
+            const auto total_hits = storage.get_total_samples_count({request.document_id()});
 
             const auto& file = stacks_analysis.get_file(*function.file_id);
 

--- a/snail/server/storage/storage.cpp
+++ b/snail/server/storage/storage.cpp
@@ -145,6 +145,7 @@ document_id storage::read_document(const std::filesystem::path& path)
     impl_->open_documents[new_id.id_] = document_storage{
         .path                 = path,
         .data_provider        = std::move(data_provider),
+        .filter               = {},
         .analysis_per_process = {},
     };
 
@@ -163,6 +164,14 @@ const analysis::data_provider& storage::get_data(const server::document_id& docu
 {
     auto& document = impl_->get_document_storage(document_id);
     return *document.data_provider;
+}
+
+void storage::apply_document_filter(const document_id& document_id, analysis::sample_filter filter)
+{
+    auto& document = impl_->get_document_storage(document_id);
+    if(document.filter == filter) return;
+    document.filter = std::move(filter);
+    document.analysis_per_process.clear();
 }
 
 const analysis::stacks_analysis& storage::get_stacks_analysis(const server::document_id& document_id,

--- a/snail/server/storage/storage.cpp
+++ b/snail/server/storage/storage.cpp
@@ -19,6 +19,7 @@ struct document_storage
 {
     std::filesystem::path                    path;
     std::unique_ptr<analysis::data_provider> data_provider;
+    analysis::sample_filter                  filter;
 
     const analysis::stacks_analysis& get_process_analysis(common::process_id_t process_id)
     {
@@ -27,7 +28,7 @@ struct document_storage
         if(data.stacks_analysis == std::nullopt)
         {
             data = analysis_data{
-                .stacks_analysis            = snail::analysis::analyze_stacks(*data_provider, data_provider->process_info(process_id)),
+                .stacks_analysis            = snail::analysis::analyze_stacks(*data_provider, data_provider->process_info(process_id), filter),
                 .functions_by_self_samples  = {},
                 .functions_by_total_samples = {},
                 .functions_by_name          = {},

--- a/snail/server/storage/storage.hpp
+++ b/snail/server/storage/storage.hpp
@@ -4,8 +4,6 @@
 #include <memory>
 #include <span>
 
-#include <snail/common/types.hpp>
-
 #include <snail/analysis/data/functions.hpp>
 
 namespace snail::analysis {
@@ -13,6 +11,7 @@ namespace snail::analysis {
 struct stacks_analysis;
 struct options;
 struct sample_filter;
+struct unique_process_id;
 class path_map;
 class data_provider;
 
@@ -55,9 +54,9 @@ public:
 
     void apply_document_filter(const document_id& id, analysis::sample_filter filter);
 
-    const analysis::stacks_analysis& get_stacks_analysis(const document_id& id, common::process_id_t process_id);
+    const analysis::stacks_analysis& get_stacks_analysis(const document_id& id, analysis::unique_process_id process_id);
 
-    std::span<const analysis::function_info::id_t> get_functions_page(const document_id& id, common::process_id_t process_id,
+    std::span<const analysis::function_info::id_t> get_functions_page(const document_id& id, analysis::unique_process_id process_id,
                                                                       function_data_type sort_by, bool reversed,
                                                                       std::size_t page_size, std::size_t page_index);
 

--- a/snail/server/storage/storage.hpp
+++ b/snail/server/storage/storage.hpp
@@ -54,6 +54,8 @@ public:
 
     void apply_document_filter(const document_id& id, analysis::sample_filter filter);
 
+    std::size_t get_total_samples_count(const document_id& id);
+
     const analysis::stacks_analysis& get_stacks_analysis(const document_id& id, analysis::unique_process_id process_id);
 
     std::span<const analysis::function_info::id_t> get_functions_page(const document_id& id, analysis::unique_process_id process_id,

--- a/snail/server/storage/storage.hpp
+++ b/snail/server/storage/storage.hpp
@@ -12,6 +12,7 @@ namespace snail::analysis {
 
 struct stacks_analysis;
 struct options;
+struct sample_filter;
 class path_map;
 class data_provider;
 
@@ -51,6 +52,8 @@ public:
     void        close_document(const document_id& id);
 
     const analysis::data_provider& get_data(const document_id& id);
+
+    void apply_document_filter(const document_id& id, analysis::sample_filter filter);
 
     const analysis::stacks_analysis& get_stacks_analysis(const document_id& id, common::process_id_t process_id);
 

--- a/tests/integration/analysis.cpp
+++ b/tests/integration/analysis.cpp
@@ -128,7 +128,7 @@ TEST(DiagsessionDataProvider, Process)
 
     // We just compare some selected sample stacks
     const std::unordered_map<std::size_t, std::vector<analysis::stack_frame>> expected_sample_stacks = {
-        {4,
+        {3,
          {{"ntdll.dll!0x00007ffde3a5799e", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
           {"ntdll.dll!0x00007ffde3a7d9bd", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
           {"ntdll.dll!0x00007ffde3a57b98", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
@@ -145,25 +145,7 @@ TEST(DiagsessionDataProvider, Process)
           {"ntdll.dll!0x00007ffde39f47fb", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
           {"ntdll.dll!0x00007ffde39fc4f9", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
           {"ntdll.dll!0x00007ffde39fff76", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0}}                                                                                                                                                                                                                                     },
-        {34,
-         {{"ntdll.dll!0x00007ffde3a5e44b", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
-          {"kernel32.dll!0x00007ffde2e54de0", "C:\\Windows\\System32\\kernel32.dll", "", 0, 0},
-          {"mainCRTStartup", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_main.cpp", 14, 16},
-          {"__scrt_common_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 323, 330},
-          {"__scrt_common_main_seh", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 235, 287},
-          {"invoke_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 76, 78},
-          {"main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 57, 69},
-          {"void __cdecl make_random_vector(class std::vector<double, class std::allocator<double>> &, unsigned __int64)", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 11, 19}}                                                          },
-        {278,
-         {{"ntdll.dll!0x00007ffde3a5e44b", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
-          {"kernel32.dll!0x00007ffde2e54de0", "C:\\Windows\\System32\\kernel32.dll", "", 0, 0},
-          {"mainCRTStartup", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_main.cpp", 14, 16},
-          {"__scrt_common_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 323, 330},
-          {"__scrt_common_main_seh", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 235, 287},
-          {"invoke_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 76, 78},
-          {"main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 57, 71},
-          {"double __cdecl compute_inner_product(class std::vector<double, class std::allocator<double>> const &, class std::vector<double, class std::allocator<double>> const &)", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 27, 36}}},
-        {287,
+        {7,
          {{"ntdll.dll!0x00007ffde3a5e44b", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
           {"kernel32.dll!0x00007ffde2e54de0", "C:\\Windows\\System32\\kernel32.dll", "", 0, 0},
           {"ntdll.dll!0x00007ffde39ebb26", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
@@ -192,19 +174,43 @@ TEST(DiagsessionDataProvider, Process)
           {"ntoskrnl.exe!0xfffff804838f54b5", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
           {"ntoskrnl.exe!0xfffff8048389eabf", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
           {"ntoskrnl.exe!0xfffff8048389f531", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
-          {"ntoskrnl.exe!0xfffff80483a29227", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0}}                                                                                                                                                                                                                               }
+          {"ntoskrnl.exe!0xfffff80483a29227", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0}}                                                                                                                                                                                                                               },
+        {39,
+         {{"ntdll.dll!0x00007ffde3a5e44b", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
+          {"kernel32.dll!0x00007ffde2e54de0", "C:\\Windows\\System32\\kernel32.dll", "", 0, 0},
+          {"mainCRTStartup", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_main.cpp", 14, 16},
+          {"__scrt_common_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 323, 330},
+          {"__scrt_common_main_seh", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 235, 287},
+          {"invoke_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 76, 78},
+          {"main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 57, 69},
+          {"void __cdecl make_random_vector(class std::vector<double, class std::allocator<double>> &, unsigned __int64)", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 11, 19}}                                                          },
+        {96,
+         {{"ntoskrnl.exe!0xfffff80483a21be1", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff80483a27c05", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff80483a28510", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff80483a28725", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff80483838314", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff804838399cc", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff8048383c9e5", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0},
+          {"ntoskrnl.exe!0xfffff80483835de6", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0}}                                                                                                                                                                                                                               },
+        {283,
+         {{"ntdll.dll!0x00007ffde3a5e44b", "C:\\Windows\\System32\\ntdll.dll", "", 0, 0},
+          {"kernel32.dll!0x00007ffde2e54de0", "C:\\Windows\\System32\\kernel32.dll", "", 0, 0},
+          {"mainCRTStartup", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_main.cpp", 14, 16},
+          {"__scrt_common_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 323, 330},
+          {"__scrt_common_main_seh", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 235, 287},
+          {"invoke_main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/_work/1/s/src/vctools/crt/vcstartup/src/startup/exe_common.inl", 76, 78},
+          {"main", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 57, 71},
+          {"double __cdecl compute_inner_product(class std::vector<double, class std::allocator<double>> const &, class std::vector<double, class std::allocator<double>> const &)", "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe", "D:/a/snail-server/snail-server/tests/apps/inner/main.cpp", 27, 36}}}
     };
 
     for(const auto& sample : data_provider.samples(4140, {}))
     {
         ++sample_count;
 
-        // TODO: ETL samples are not currently ordered but this is not a requirement by
-        //       the analysis yet. This is going to change in the future and then we need
-        //       to fix this and enable the following check.
         const auto timestamp = sample.timestamp();
-        // ASSERT_LE(last_timestamp, timestamp);
-        last_timestamp       = timestamp;
+        ASSERT_LE(last_timestamp, timestamp);
+        last_timestamp = timestamp;
 
         const auto sample_index = sample_count - 1;
         if(!expected_sample_stacks.contains(sample_index)) continue;

--- a/tests/integration/analysis.cpp
+++ b/tests/integration/analysis.cpp
@@ -195,7 +195,7 @@ TEST(DiagsessionDataProvider, Process)
           {"ntoskrnl.exe!0xfffff80483a29227", "C:\\Windows\\system32\\ntoskrnl.exe", "", 0, 0}}                                                                                                                                                                                                                               }
     };
 
-    for(const auto& sample : data_provider.samples(4140))
+    for(const auto& sample : data_provider.samples(4140, {}))
     {
         ++sample_count;
 
@@ -297,7 +297,7 @@ TEST(PerfDataDataProvider, Process)
           {"compute_inner_product(std::vector<double, std::allocator<double>> const&, std::vector<double, std::allocator<double>> const&)", "/tmp/build/inner/Debug/build/inner", "/tmp/snail-server/tests/apps/inner/main.cpp", 26, 35}}}
     };
 
-    for(const auto& sample : data_provider.samples(248))
+    for(const auto& sample : data_provider.samples(248, {}))
     {
         ++sample_count;
 

--- a/tests/integration/analysis.cpp
+++ b/tests/integration/analysis.cpp
@@ -229,6 +229,7 @@ TEST(DiagsessionDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 292);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 292);
 
     // Filter complete range
     filter.min_time = 1073706700ns;
@@ -253,6 +254,7 @@ TEST(DiagsessionDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 292);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 292);
 
     // Filter first half
     filter.min_time = std::nullopt;
@@ -277,6 +279,7 @@ TEST(DiagsessionDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 11);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 11);
 
     // Filter second half
     filter.min_time = 1818779600ns;
@@ -301,6 +304,7 @@ TEST(DiagsessionDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 281);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 281);
 
     // Filter somewhere in the middle
     filter.min_time = 2200000000ns;
@@ -325,6 +329,7 @@ TEST(DiagsessionDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 99);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 99);
 
     // None empty
     filter.min_time = 2300000000ns;
@@ -336,6 +341,7 @@ TEST(DiagsessionDataProvider, Process)
         ++sample_count;
     }
     EXPECT_EQ(sample_count, 0);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 0);
 }
 
 TEST(PerfDataDataProvider, Process)
@@ -436,6 +442,7 @@ TEST(PerfDataDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 1524);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 1524);
 
     // Filter complete range
     filter.min_time = 0ns;
@@ -460,6 +467,7 @@ TEST(PerfDataDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 1524);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 1524);
 
     // Filter first half
     filter.min_time = std::nullopt;
@@ -484,6 +492,7 @@ TEST(PerfDataDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 755);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 755);
 
     // Filter second half
     filter.min_time = 193699200ns;
@@ -508,6 +517,7 @@ TEST(PerfDataDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 769);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 769);
 
     // Filter somewhere in the middle
     filter.min_time = 180000000ns;
@@ -532,6 +542,7 @@ TEST(PerfDataDataProvider, Process)
         EXPECT_EQ(stack, expected_stack);
     }
     EXPECT_EQ(sample_count, 80);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 80);
 
     // None empty
     filter.min_time = 230000000ns;
@@ -543,4 +554,5 @@ TEST(PerfDataDataProvider, Process)
         ++sample_count;
     }
     EXPECT_EQ(sample_count, 0);
+    EXPECT_EQ(data_provider.count_samples(unique_sampling_process_id, filter), 0);
 }

--- a/tests/integration/analysis.cpp
+++ b/tests/integration/analysis.cpp
@@ -92,36 +92,39 @@ TEST(DiagsessionDataProvider, Process)
     EXPECT_EQ(data_provider.system_info().cpu_name, "Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz");
     EXPECT_EQ(data_provider.system_info().number_of_processors, 2);
 
-    EXPECT_EQ(to_vector(data_provider.sampling_processes()), (std::vector<common::process_id_t>{4140}));
+    const auto sampling_processes = to_vector(data_provider.sampling_processes());
+    ASSERT_EQ(sampling_processes.size(), 1);
+    const auto unique_sampling_process_id = sampling_processes[0];
 
-    const auto process_info = data_provider.process_info(4140);
-    EXPECT_EQ(process_info.id, 4140);
+    const auto process_info = data_provider.process_info(unique_sampling_process_id);
+    EXPECT_EQ(process_info.unique_id, unique_sampling_process_id);
+    EXPECT_EQ(process_info.os_id, 4140);
     EXPECT_EQ(process_info.name, "inner.exe");
     EXPECT_EQ(process_info.start_time, 56312800ns);
     EXPECT_EQ(process_info.end_time, 2564215900ns);
 
-    const auto threads = to_vector(data_provider.threads_info(4140));
+    const auto threads = to_vector(data_provider.threads_info(unique_sampling_process_id));
     ASSERT_EQ(threads.size(), 4);
 
-    EXPECT_EQ(threads[0].id, 3148);
-    EXPECT_EQ(threads[0].name, std::nullopt);
-    EXPECT_EQ(threads[0].start_time, 1137927400ns);
-    EXPECT_EQ(threads[0].end_time, 2563524800ns);
-
-    EXPECT_EQ(threads[1].id, 3828);
-    EXPECT_EQ(threads[1].name, std::nullopt);
-    EXPECT_EQ(threads[1].start_time, 56313900ns);
-    EXPECT_EQ(threads[1].end_time, 2563993900ns);
-
-    EXPECT_EQ(threads[2].id, 4224);
-    EXPECT_EQ(threads[2].name, std::nullopt);
-    EXPECT_EQ(threads[2].start_time, 1138034300ns);
-    EXPECT_EQ(threads[2].end_time, 2563493400ns);
-
-    EXPECT_EQ(threads[3].id, 6180);
+    EXPECT_EQ(threads[3].os_id, 3148);
     EXPECT_EQ(threads[3].name, std::nullopt);
-    EXPECT_EQ(threads[3].start_time, 1137662800ns);
-    EXPECT_EQ(threads[3].end_time, 2563540200ns);
+    EXPECT_EQ(threads[3].start_time, 1137927400ns);
+    EXPECT_EQ(threads[3].end_time, 2563524800ns);
+
+    EXPECT_EQ(threads[2].os_id, 3828);
+    EXPECT_EQ(threads[2].name, std::nullopt);
+    EXPECT_EQ(threads[2].start_time, 56313900ns);
+    EXPECT_EQ(threads[2].end_time, 2563993900ns);
+
+    EXPECT_EQ(threads[0].os_id, 4224);
+    EXPECT_EQ(threads[0].name, std::nullopt);
+    EXPECT_EQ(threads[0].start_time, 1138034300ns);
+    EXPECT_EQ(threads[0].end_time, 2563493400ns);
+
+    EXPECT_EQ(threads[1].os_id, 6180);
+    EXPECT_EQ(threads[1].name, std::nullopt);
+    EXPECT_EQ(threads[1].start_time, 1137662800ns);
+    EXPECT_EQ(threads[1].end_time, 2563540200ns);
 
     analysis::sample_filter  filter;
     std::chrono::nanoseconds last_timestamp;
@@ -208,7 +211,7 @@ TEST(DiagsessionDataProvider, Process)
     // No filter
     sample_count   = 0;
     last_timestamp = 0ns;
-    for(const auto& sample : data_provider.samples(4140, {}))
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, {}))
     {
         ++sample_count;
 
@@ -232,7 +235,7 @@ TEST(DiagsessionDataProvider, Process)
     filter.max_time = 2563852500ns;
     sample_count    = 0;
     last_timestamp  = 0ns;
-    for(const auto& sample : data_provider.samples(4140, filter))
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
     {
         ++sample_count;
 
@@ -256,7 +259,7 @@ TEST(DiagsessionDataProvider, Process)
     filter.max_time = 1818779600ns;
     sample_count    = 0;
     last_timestamp  = 0ns;
-    for(const auto& sample : data_provider.samples(4140, filter))
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
     {
         ++sample_count;
 
@@ -280,7 +283,7 @@ TEST(DiagsessionDataProvider, Process)
     filter.max_time = std::nullopt;
     sample_count    = 0;
     last_timestamp  = 0ns;
-    for(const auto& sample : data_provider.samples(4140, filter))
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
     {
         ++sample_count;
 
@@ -304,7 +307,7 @@ TEST(DiagsessionDataProvider, Process)
     filter.max_time = 2300000000ns;
     sample_count    = 0;
     last_timestamp  = 0ns;
-    for(const auto& sample : data_provider.samples(4140, filter))
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
     {
         ++sample_count;
 
@@ -328,7 +331,7 @@ TEST(DiagsessionDataProvider, Process)
     filter.max_time = 2200000000ns;
     sample_count    = 0;
     last_timestamp  = 0ns;
-    for([[maybe_unused]] const auto& sample : data_provider.samples(4140, filter))
+    for([[maybe_unused]] const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
     {
         ++sample_count;
     }
@@ -359,7 +362,7 @@ TEST(PerfDataDataProvider, Process)
     // EXPECT_EQ(data_provider.session_info().date, std::chrono::sys_seconds(1688327245s)); // This is not stable
     EXPECT_EQ(data_provider.session_info().runtime, 387398400ns);
     EXPECT_EQ(data_provider.session_info().number_of_processes, 1);
-    EXPECT_EQ(data_provider.session_info().number_of_threads, 2);
+    EXPECT_EQ(data_provider.session_info().number_of_threads, 1);
     EXPECT_EQ(data_provider.session_info().number_of_samples, 1524);
     EXPECT_EQ(data_provider.session_info().average_sampling_rate, 3933.9346780988258);
 
@@ -369,30 +372,28 @@ TEST(PerfDataDataProvider, Process)
     EXPECT_EQ(data_provider.system_info().cpu_name, "Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz");
     EXPECT_EQ(data_provider.system_info().number_of_processors, 8);
 
-    EXPECT_EQ(to_vector(data_provider.sampling_processes()), (std::vector<common::process_id_t>{248}));
+    const auto sampling_processes = to_vector(data_provider.sampling_processes());
+    ASSERT_EQ(sampling_processes.size(), 1);
+    const auto unique_sampling_process_id = sampling_processes[0];
 
-    const auto process_info = data_provider.process_info(248);
-    EXPECT_EQ(process_info.id, 248);
+    const auto process_info = data_provider.process_info(unique_sampling_process_id);
+    EXPECT_EQ(process_info.unique_id, unique_sampling_process_id);
+    EXPECT_EQ(process_info.os_id, 248);
     EXPECT_EQ(process_info.name, "inner");
     EXPECT_EQ(process_info.start_time, 0ns);
     EXPECT_EQ(process_info.end_time, 387398400ns);
 
-    const auto threads = to_vector(data_provider.threads_info(248));
-    ASSERT_EQ(threads.size(), 2);
+    const auto threads = to_vector(data_provider.threads_info(unique_sampling_process_id));
+    ASSERT_EQ(threads.size(), 1);
 
-    // TODO: we probably should make sure thread lifetimes do not overlap (here it is just a renaming)
-    EXPECT_EQ(threads[0].id, 248);
-    EXPECT_EQ(threads[0].name, "perf-exec");
+    EXPECT_EQ(threads[0].os_id, 248);
+    EXPECT_EQ(threads[0].name, "inner");
     EXPECT_EQ(threads[0].start_time, 0ns);
     EXPECT_EQ(threads[0].end_time, 387398400ns);
 
-    EXPECT_EQ(threads[1].id, 248);
-    EXPECT_EQ(threads[1].name, "inner");
-    EXPECT_EQ(threads[1].start_time, 0ns);
-    EXPECT_EQ(threads[1].end_time, 387398400ns);
-
-    std::chrono::nanoseconds last_timestamp = 0ns;
-    std::size_t              sample_count   = 0;
+    analysis::sample_filter  filter;
+    std::chrono::nanoseconds last_timestamp;
+    std::size_t              sample_count;
 
     // We just compare some selected sample stacks
     const std::unordered_map<std::size_t, std::vector<analysis::stack_frame>> expected_sample_stacks = {
@@ -413,7 +414,10 @@ TEST(PerfDataDataProvider, Process)
           {"compute_inner_product(std::vector<double, std::allocator<double>> const&, std::vector<double, std::allocator<double>> const&)", "/tmp/build/inner/Debug/build/inner", "/tmp/snail-server/tests/apps/inner/main.cpp", 26, 35}}}
     };
 
-    for(const auto& sample : data_provider.samples(248, {}))
+    // No filter
+    sample_count   = 0;
+    last_timestamp = 0ns;
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, {}))
     {
         ++sample_count;
 
@@ -431,6 +435,112 @@ TEST(PerfDataDataProvider, Process)
 
         EXPECT_EQ(stack, expected_stack);
     }
-
     EXPECT_EQ(sample_count, 1524);
+
+    // Filter complete range
+    filter.min_time = 0ns;
+    filter.max_time = 387398400ns;
+    sample_count    = 0;
+    last_timestamp  = 0ns;
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
+    {
+        ++sample_count;
+
+        const auto timestamp = sample.timestamp();
+        ASSERT_LE(last_timestamp, timestamp);
+        last_timestamp = timestamp;
+
+        const auto sample_index = sample_count - 1;
+        if(!expected_sample_stacks.contains(sample_index)) continue;
+
+        const auto expected_stack = expected_sample_stacks.at(sample_index);
+
+        const auto stack = to_vector(sample.reversed_stack());
+
+        EXPECT_EQ(stack, expected_stack);
+    }
+    EXPECT_EQ(sample_count, 1524);
+
+    // Filter first half
+    filter.min_time = std::nullopt;
+    filter.max_time = 193699200ns;
+    sample_count    = 0;
+    last_timestamp  = 0ns;
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
+    {
+        ++sample_count;
+
+        const auto timestamp = sample.timestamp();
+        ASSERT_LE(last_timestamp, timestamp);
+        last_timestamp = timestamp;
+
+        const auto sample_index = sample_count - 1;
+        if(!expected_sample_stacks.contains(sample_index)) continue;
+
+        const auto expected_stack = expected_sample_stacks.at(sample_index);
+
+        const auto stack = to_vector(sample.reversed_stack());
+
+        EXPECT_EQ(stack, expected_stack);
+    }
+    EXPECT_EQ(sample_count, 755);
+
+    // Filter second half
+    filter.min_time = 193699200ns;
+    filter.max_time = std::nullopt;
+    sample_count    = 0;
+    last_timestamp  = 0ns;
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
+    {
+        ++sample_count;
+
+        const auto timestamp = sample.timestamp();
+        ASSERT_LE(last_timestamp, timestamp);
+        last_timestamp = timestamp;
+
+        const auto sample_index = sample_count - 1 + 755;
+        if(!expected_sample_stacks.contains(sample_index)) continue;
+
+        const auto expected_stack = expected_sample_stacks.at(sample_index);
+
+        const auto stack = to_vector(sample.reversed_stack());
+
+        EXPECT_EQ(stack, expected_stack);
+    }
+    EXPECT_EQ(sample_count, 769);
+
+    // Filter somewhere in the middle
+    filter.min_time = 180000000ns;
+    filter.max_time = 200000000ns;
+    sample_count    = 0;
+    last_timestamp  = 0ns;
+    for(const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
+    {
+        ++sample_count;
+
+        const auto timestamp = sample.timestamp();
+        ASSERT_LE(last_timestamp, timestamp);
+        last_timestamp = timestamp;
+
+        const auto sample_index = sample_count - 1 + 700;
+        if(!expected_sample_stacks.contains(sample_index)) continue;
+
+        const auto expected_stack = expected_sample_stacks.at(sample_index);
+
+        const auto stack = to_vector(sample.reversed_stack());
+
+        EXPECT_EQ(stack, expected_stack);
+    }
+    EXPECT_EQ(sample_count, 80);
+
+    // None empty
+    filter.min_time = 230000000ns;
+    filter.max_time = 220000000ns;
+    sample_count    = 0;
+    last_timestamp  = 0ns;
+    for([[maybe_unused]] const auto& sample : data_provider.samples(unique_sampling_process_id, filter))
+    {
+        ++sample_count;
+    }
+    EXPECT_EQ(sample_count, 0);
 }

--- a/tests/system/client/src/protocol.ts
+++ b/tests/system/client/src/protocol.ts
@@ -9,7 +9,9 @@ export enum ModuleFilterMode {
 }
 
 export interface ThreadInfo {
-    id: number;
+    key: number;
+
+    osId: number;
 
     // Time when the thread started (in nanoseconds since the session start).
     startTime: number;
@@ -21,7 +23,9 @@ export interface ThreadInfo {
 }
 
 export interface ProcessInfo {
-    id: number;
+    key: number;
+
+    osId: number;
 
     name: string;
 
@@ -106,7 +110,7 @@ export interface FunctionNode {
 }
 
 export interface ProcessFunction {
-    processId: number;
+    processKey: number;
 
     function: FunctionNode;
 }
@@ -181,7 +185,7 @@ export interface RetrieveHottestFunctionsResult {
 }
 
 export interface RetrieveCallTreeHotPathParams {
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -197,7 +201,7 @@ export interface RetrieveFunctionsPageParams {
 
     pageIndex: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -211,7 +215,7 @@ export interface RetrieveFunctionsPageResult {
 export interface ExpandCallTreeNodeParams {
     nodeId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -227,7 +231,7 @@ export interface RetrieveCallersCalleesParams {
 
     functionId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
@@ -245,7 +249,7 @@ export interface RetrieveCallersCalleesResult {
 export interface RetrieveLineInfoParams {
     functionId: number;
 
-    processId: number;
+    processKey: number;
 
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.

--- a/tests/system/client/src/protocol.ts
+++ b/tests/system/client/src/protocol.ts
@@ -308,6 +308,18 @@ export interface SetModuleFiltersParams {
     include: string[];
 }
 
+export interface SetSampleFiltersParams {
+    // The id of the document to perform the operation on.
+    // This should be an id that resulted from a call to `readDocument`.
+    documentId: number;
+
+    // In nanoseconds since session start.
+    minTime: number | null;
+
+    // In nanoseconds since session start.
+    maxTime: number | null;
+}
+
 
 export const initializeRequestType = new rpc.RequestType<InitializeParams, InitializeResult, void>('initialize');
 
@@ -343,6 +355,9 @@ export const retrieveCallersCalleesRequestType = new rpc.RequestType<RetrieveCal
 
 
 export const retrieveLineInfoRequestType = new rpc.RequestType<RetrieveLineInfoParams, RetrieveLineInfoResult | null, void>('retrieveLineInfo');
+
+
+export const setSampleFiltersRequestType = new rpc.RequestType<SetSampleFiltersParams, null, void>('setSampleFilters');
 
 
 export const closeDocumentNotificationType = new rpc.NotificationType<CloseDocumentParams>('closeDocument');

--- a/tests/system/client/src/protocol.ts
+++ b/tests/system/client/src/protocol.ts
@@ -313,6 +313,10 @@ export interface SetModuleFiltersParams {
 }
 
 export interface SetSampleFiltersParams {
+    excludedProcesses: number[];
+
+    excludedThreads: number[];
+
     // The id of the document to perform the operation on.
     // This should be an id that resulted from a call to `readDocument`.
     documentId: number;

--- a/tests/system/client/tests/diagsession.test.ts
+++ b/tests/system/client/tests/diagsession.test.ts
@@ -82,7 +82,7 @@ describe("InnerDiagsession", function () {
         assert.strictEqual(response.systemInfo.numberOfProcessors, 2);
     });
 
-    it("systemInfo", async () => {
+    it("sessionInfo", async () => {
         const response = await fixture.connection.sendRequest(snail.retrieveSessionInfoRequestType, {
             documentId: documentId
         });
@@ -102,53 +102,73 @@ describe("InnerDiagsession", function () {
         });
 
         assert.strictEqual(response.processes.length, 1);
-        assert.strictEqual(response.processes[0].id, 4140);
+        assert.strictEqual(response.processes[0].osId, 4140);
         assert.strictEqual(response.processes[0].name, "inner.exe");
         assert.strictEqual(response.processes[0].startTime, 56312800);
         assert.strictEqual(response.processes[0].endTime, 2564215900);
 
         assert.strictEqual(response.processes[0].threads.length, 4);
 
-        assert.strictEqual(response.processes[0].threads[0].id, 3148);
-        assert.strictEqual(response.processes[0].threads[0].name, null);
-        assert.strictEqual(response.processes[0].threads[0].startTime, 1137927400);
-        assert.strictEqual(response.processes[0].threads[0].endTime, 2563524800);
+        const thread_3148 = response.processes[0].threads.find(thread => thread.osId == 3148);
+        assert.isDefined(thread_3148);
+        assert.strictEqual(thread_3148!.osId, 3148);
+        assert.strictEqual(thread_3148!.name, null);
+        assert.strictEqual(thread_3148!.startTime, 1137927400);
+        assert.strictEqual(thread_3148!.endTime, 2563524800);
 
-        assert.strictEqual(response.processes[0].threads[1].id, 3828);
-        assert.strictEqual(response.processes[0].threads[1].name, null);
-        assert.strictEqual(response.processes[0].threads[1].startTime, 56313900);
-        assert.strictEqual(response.processes[0].threads[1].endTime, 2563993900);
+        const thread_3828 = response.processes[0].threads.find(thread => thread.osId == 3828);
+        assert.isDefined(thread_3828);
+        assert.strictEqual(thread_3828!.osId, 3828);
+        assert.strictEqual(thread_3828!.name, null);
+        assert.strictEqual(thread_3828!.startTime, 56313900);
+        assert.strictEqual(thread_3828!.endTime, 2563993900);
 
-        assert.strictEqual(response.processes[0].threads[2].id, 4224);
-        assert.strictEqual(response.processes[0].threads[2].name, null);
-        assert.strictEqual(response.processes[0].threads[2].startTime, 1138034300);
-        assert.strictEqual(response.processes[0].threads[2].endTime, 2563493400);
+        const thread_4224 = response.processes[0].threads.find(thread => thread.osId == 4224);
+        assert.isDefined(thread_4224);
+        assert.strictEqual(thread_4224!.osId, 4224);
+        assert.strictEqual(thread_4224!.name, null);
+        assert.strictEqual(thread_4224!.startTime, 1138034300);
+        assert.strictEqual(thread_4224!.endTime, 2563493400);
 
-        assert.strictEqual(response.processes[0].threads[3].id, 6180);
-        assert.strictEqual(response.processes[0].threads[3].name, null);
-        assert.strictEqual(response.processes[0].threads[3].startTime, 1137662800);
-        assert.strictEqual(response.processes[0].threads[3].endTime, 2563540200);
+        const thread_6180 = response.processes[0].threads.find(thread => thread.osId == 6180);
+        assert.isDefined(thread_6180);
+        assert.strictEqual(thread_6180!.osId, 6180);
+        assert.strictEqual(thread_6180!.name, null);
+        assert.strictEqual(thread_6180!.startTime, 1137662800);
+        assert.strictEqual(thread_6180!.endTime, 2563540200);
     });
 
     it("hottestFunctions_1", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveHottestFunctionsRequestType, {
             documentId: documentId,
             count: 1
         });
 
         assert.strictEqual(response.functions.length, 1);
-        assert.strictEqual(response.functions[0].processId, 4140);
+        assert.strictEqual(response.functions[0].processKey, process!.key);
         assert.strictEqual(response.functions[0].function.name, "double __cdecl std::generate_canonical<double, 53, class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>>(class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253> &)");
         assert.isAtLeast(response.functions[0].function.id, 0);
         assert.strictEqual(response.functions[0].function.module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
         assert.strictEqual(response.functions[0].function.type, "function");
-        assert.strictEqual(response.functions[0].function.totalSamples, 109);
+        assert.strictEqual(response.functions[0].function.totalSamples, 108);
         assert.strictEqual(response.functions[0].function.selfSamples, 34);
-        assert.strictEqual(response.functions[0].function.totalPercent, 37.32876712328767);
+        assert.strictEqual(response.functions[0].function.totalPercent, 36.986301369863014);
         assert.strictEqual(response.functions[0].function.selfPercent, 11.643835616438356);
     });
 
     it("hottestFunctions_3", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveHottestFunctionsRequestType, {
             documentId: documentId,
             count: 3
@@ -156,27 +176,27 @@ describe("InnerDiagsession", function () {
 
         assert.strictEqual(response.functions.length, 3);
 
-        assert.strictEqual(response.functions[0].processId, 4140);
+        assert.strictEqual(response.functions[0].processKey, process!.key);
         assert.strictEqual(response.functions[0].function.name, "double __cdecl std::generate_canonical<double, 53, class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>>(class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253> &)");
         assert.isAtLeast(response.functions[0].function.id, 0);
         assert.strictEqual(response.functions[0].function.module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
         assert.strictEqual(response.functions[0].function.type, "function");
-        assert.strictEqual(response.functions[0].function.totalSamples, 109);
+        assert.strictEqual(response.functions[0].function.totalSamples, 108);
         assert.strictEqual(response.functions[0].function.selfSamples, 34);
-        assert.strictEqual(response.functions[0].function.totalPercent, 37.32876712328767);
+        assert.strictEqual(response.functions[0].function.totalPercent, 36.986301369863014);
         assert.strictEqual(response.functions[0].function.selfPercent, 11.643835616438356);
 
-        assert.strictEqual(response.functions[1].processId, 4140);
+        assert.strictEqual(response.functions[1].processKey, process!.key);
         assert.strictEqual(response.functions[1].function.name, "public: unsigned int __cdecl std::mersenne_twister<unsigned int, 32, 624, 397, 31, 2567483615, 11, 7, 2636928640, 15, 4022730752, 18>::operator()(void)");
         assert.isAtLeast(response.functions[1].function.id, 0);
         assert.strictEqual(response.functions[1].function.module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
         assert.strictEqual(response.functions[1].function.type, "function");
-        assert.strictEqual(response.functions[1].function.totalSamples, 74);
+        assert.strictEqual(response.functions[1].function.totalSamples, 73);
         assert.strictEqual(response.functions[1].function.selfSamples, 30);
-        assert.strictEqual(response.functions[1].function.totalPercent, 25.34246575342466);
+        assert.strictEqual(response.functions[1].function.totalPercent, 25);
         assert.strictEqual(response.functions[1].function.selfPercent, 10.273972602739725);
 
-        assert.strictEqual(response.functions[2].processId, 4140);
+        assert.strictEqual(response.functions[2].processKey, process!.key);
         assert.strictEqual(response.functions[2].function.name, "private: void __cdecl std::vector<double, class std::allocator<double>>::_Orphan_range_locked(double *, double *) const");
         assert.isAtLeast(response.functions[2].function.id, 0);
         assert.strictEqual(response.functions[2].function.module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
@@ -187,11 +207,16 @@ describe("InnerDiagsession", function () {
         assert.strictEqual(response.functions[2].function.selfPercent, 8.219178082191782);
     });
 
-
     it("callTreeHotPath", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
             documentId: documentId,
-            processId: 4140
+            processKey: process!.key
         });
 
         const root_id = 4294967295; // uint32 max
@@ -206,15 +231,19 @@ describe("InnerDiagsession", function () {
         assert.strictEqual(response.root.totalPercent, 100);
         assert.strictEqual(response.root.selfPercent, 0);
         assert.strictEqual(response.root.type, "process");
-        assert.strictEqual(response.root.children?.length, 2);
+        assert.strictEqual(response.root.children?.length, 3);
 
-        assert.strictEqual(response.root.children?.at(1)?.name, "LdrInitializeThunk");
-        assert.isFalse(response.root.children?.at(1)?.isHot);
-        assert.isNull(response.root.children?.at(1)?.children);
+        assert.strictEqual(response.root.children?.at(0)?.name, "LdrInitializeThunk");
+        assert.isFalse(response.root.children?.at(0)?.isHot);
+        assert.isNull(response.root.children?.at(0)?.children);
 
-        let next = response.root.children?.at(0);
-        assert.strictEqual(next?.name, "RtlUserThreadStart");
+        assert.strictEqual(response.root.children?.at(2)?.name, "ntoskrnl.exe!0xfffff80483a21be1");
+        assert.isFalse(response.root.children?.at(2)?.isHot);
+        assert.isNull(response.root.children?.at(2)?.children);
+
+        let next = response.root.children?.at(1);
         assert.isTrue(next?.isHot);
+        assert.strictEqual(next?.name, "RtlUserThreadStart");
         assert.strictEqual(next?.children?.length, 1);
 
         next = next?.children?.at(0);
@@ -287,9 +316,15 @@ describe("InnerDiagsession", function () {
     });
 
     it("functionPage", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             pageSize: 3,
             pageIndex: 0
         });
@@ -299,18 +334,18 @@ describe("InnerDiagsession", function () {
         assert.isAtLeast(response.functions[0].id, 0);
         assert.strictEqual(response.functions[0].module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
         assert.strictEqual(response.functions[0].name, "double __cdecl std::generate_canonical<double, 53, class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>>(class std::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253> &)");
-        assert.strictEqual(response.functions[0].totalSamples, 109);
+        assert.strictEqual(response.functions[0].totalSamples, 108);
         assert.strictEqual(response.functions[0].selfSamples, 34);
-        assert.strictEqual(response.functions[0].totalPercent, 37.32876712328767);
+        assert.strictEqual(response.functions[0].totalPercent, 36.986301369863014);
         assert.strictEqual(response.functions[0].selfPercent, 11.643835616438356);
         assert.strictEqual(response.functions[0].type, "function");
 
         assert.isAtLeast(response.functions[1].id, 0);
         assert.strictEqual(response.functions[1].module, "D:\\a\\snail-server\\snail-server\\inner\\Debug\\build\\inner.exe");
         assert.strictEqual(response.functions[1].name, "public: unsigned int __cdecl std::mersenne_twister<unsigned int, 32, 624, 397, 31, 2567483615, 11, 7, 2636928640, 15, 4022730752, 18>::operator()(void)");
-        assert.strictEqual(response.functions[1].totalSamples, 74);
+        assert.strictEqual(response.functions[1].totalSamples, 73);
         assert.strictEqual(response.functions[1].selfSamples, 30);
-        assert.strictEqual(response.functions[1].totalPercent, 25.34246575342466);
+        assert.strictEqual(response.functions[1].totalPercent, 25);
         assert.strictEqual(response.functions[1].selfPercent, 10.273972602739725);
         assert.strictEqual(response.functions[1].type, "function");
 
@@ -325,13 +360,18 @@ describe("InnerDiagsession", function () {
     });
 
     it("expandCallTreeNode", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
 
-        const hot_path = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
+        const hotPathResponse = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
             documentId: documentId,
-            processId: 4140
+            processKey: process!.key
         });
 
-        var current: snail.CallTreeNode | null = hot_path.root;
+        var current: snail.CallTreeNode | null = hotPathResponse.root;
         while (current && current.children) {
             if (current.name === "main") {
                 break;
@@ -357,7 +397,7 @@ describe("InnerDiagsession", function () {
 
         const response = await fixture.connection.sendRequest(snail.expandCallTreeNodeRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             nodeId: current?.id
         });
 
@@ -377,10 +417,15 @@ describe("InnerDiagsession", function () {
     });
 
     it("callersCalleesMain", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             pageSize: 500,
             pageIndex: 0
         });
@@ -390,7 +435,7 @@ describe("InnerDiagsession", function () {
 
         const response = await fixture.connection.sendRequest(snail.retrieveCallersCalleesRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             functionId: func!.id,
             maxEntries: 2
         });
@@ -405,20 +450,24 @@ describe("InnerDiagsession", function () {
     });
 
     it("lineInfoMain", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             pageSize: 500,
             pageIndex: 0
         });
-
         const func = functionsPage.functions.find(func => func.name == "main");
         assert.isDefined(func);
 
         const response = await fixture.connection.sendRequest(snail.retrieveLineInfoRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             functionId: func!.id,
         });
 
@@ -426,9 +475,9 @@ describe("InnerDiagsession", function () {
 
         assert.strictEqual(response!.filePath, "D:\\a\\snail-server\\snail-server\\tests\\apps\\inner\\main.cpp");
         assert.strictEqual(response!.lineNumber, 57);
-        assert.strictEqual(response!.totalSamples, 276);
+        assert.strictEqual(response!.totalSamples, 275);
         assert.strictEqual(response!.selfSamples, 0);
-        assert.strictEqual(response!.totalPercent, 94.52054794520548);
+        assert.strictEqual(response!.totalPercent, 94.17808219178082);
         assert.strictEqual(response!.selfPercent, 0);
 
         response!.lineHits.sort((a, b) => {
@@ -444,9 +493,9 @@ describe("InnerDiagsession", function () {
         assert.strictEqual(response!.lineHits[0].selfPercent, 0);
 
         assert.strictEqual(response!.lineHits[1].lineNumber, 69);
-        assert.strictEqual(response!.lineHits[1].totalSamples, 134);
+        assert.strictEqual(response!.lineHits[1].totalSamples, 133);
         assert.strictEqual(response!.lineHits[1].selfSamples, 0);
-        assert.strictEqual(response!.lineHits[1].totalPercent, 45.89041095890411);
+        assert.strictEqual(response!.lineHits[1].totalPercent, 45.54794520547945);
         assert.strictEqual(response!.lineHits[1].selfPercent, 0);
 
         assert.strictEqual(response!.lineHits[2].lineNumber, 71);
@@ -463,20 +512,24 @@ describe("InnerDiagsession", function () {
     });
 
     it("lineInfoUnknown", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 4140);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             pageSize: 50,
             pageIndex: 0
         });
-
         const func = functionsPage.functions.find(func => func.name.startsWith("ntoskrnl.exe!"));
         assert.isDefined(func);
 
         const response = await fixture.connection.sendRequest(snail.retrieveLineInfoRequestType, {
             documentId: documentId,
-            processId: 4140,
+            processKey: process!.key,
             functionId: func!.id,
         });
 

--- a/tests/system/client/tests/perf_data.test.ts
+++ b/tests/system/client/tests/perf_data.test.ts
@@ -69,7 +69,7 @@ describe("InnerPerfData", function () {
         assert.strictEqual(response.systemInfo.numberOfProcessors, 8);
     });
 
-    it("systemInfo", async () => {
+    it("sessionInfo", async () => {
         const response = await fixture.connection.sendRequest(snail.retrieveSessionInfoRequestType, {
             documentId: documentId
         });
@@ -78,7 +78,7 @@ describe("InnerPerfData", function () {
         // assert.strictEqual(response.sessionInfo.date, "2023-07-02T19:47+0000");
         assert.strictEqual(response.sessionInfo.runtime, 387398400);
         assert.strictEqual(response.sessionInfo.numberOfProcesses, 1);
-        assert.strictEqual(response.sessionInfo.numberOfThreads, 2);
+        assert.strictEqual(response.sessionInfo.numberOfThreads, 1);
         assert.strictEqual(response.sessionInfo.numberOfSamples, 1524);
         assert.strictEqual(response.sessionInfo.averageSamplingRate, 3933.9346780988258);
     });
@@ -90,32 +90,33 @@ describe("InnerPerfData", function () {
 
         assert.strictEqual(response.processes.length, 1);
 
-        assert.strictEqual(response.processes[0].id, 248);
+        assert.strictEqual(response.processes[0].osId, 248);
         assert.strictEqual(response.processes[0].name, "inner");
         assert.strictEqual(response.processes[0].startTime, 0);
         assert.strictEqual(response.processes[0].endTime, 387398400);
 
-        assert.strictEqual(response.processes[0].threads.length, 2);
+        assert.strictEqual(response.processes[0].threads.length, 1);
 
-        assert.strictEqual(response.processes[0].threads[0].id, 248);
-        assert.strictEqual(response.processes[0].threads[0].name, "perf-exec");
+        assert.strictEqual(response.processes[0].threads[0].osId, 248);
+        assert.strictEqual(response.processes[0].threads[0].name, "inner");
         assert.strictEqual(response.processes[0].threads[0].startTime, 0);
         assert.strictEqual(response.processes[0].threads[0].endTime, 387398400);
-
-        assert.strictEqual(response.processes[0].threads[1].id, 248);
-        assert.strictEqual(response.processes[0].threads[1].name, "inner");
-        assert.strictEqual(response.processes[0].threads[1].startTime, 0);
-        assert.strictEqual(response.processes[0].threads[1].endTime, 387398400);
     });
 
     it("hottestFunctions_1", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveHottestFunctionsRequestType, {
             documentId: documentId,
             count: 1
         });
 
         assert.strictEqual(response.functions.length, 1);
-        assert.strictEqual(response.functions[0].processId, 248);
+        assert.strictEqual(response.functions[0].processKey, process!.key);
         assert.strictEqual(response.functions[0].function.name, "double std::generate_canonical<double, 53ul, std::mersenne_twister_engine<unsigned long, 32ul, 624ul, 397ul, 31ul, 2567483615ul, 11ul, 4294967295ul, 7ul, 2636928640ul, 15ul, 4022730752ul, 18ul, 1812433253ul>>(std::mersenne_twister_engine<unsigned long, 32ul, 624ul, 397ul, 31ul, 2567483615ul, 11ul, 4294967295ul, 7ul, 2636928640ul, 15ul, 4022730752ul, 18ul, 1812433253ul>&)");
         assert.isAtLeast(response.functions[0].function.id, 0);
         assert.strictEqual(response.functions[0].function.module, "/tmp/build/inner/Debug/build/inner");
@@ -127,6 +128,12 @@ describe("InnerPerfData", function () {
     });
 
     it("hottestFunctions_3", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveHottestFunctionsRequestType, {
             documentId: documentId,
             count: 3
@@ -134,7 +141,7 @@ describe("InnerPerfData", function () {
 
         assert.strictEqual(response.functions.length, 3);
 
-        assert.strictEqual(response.functions[0].processId, 248);
+        assert.strictEqual(response.functions[0].processKey, process!.key);
         assert.strictEqual(response.functions[0].function.name, "double std::generate_canonical<double, 53ul, std::mersenne_twister_engine<unsigned long, 32ul, 624ul, 397ul, 31ul, 2567483615ul, 11ul, 4294967295ul, 7ul, 2636928640ul, 15ul, 4022730752ul, 18ul, 1812433253ul>>(std::mersenne_twister_engine<unsigned long, 32ul, 624ul, 397ul, 31ul, 2567483615ul, 11ul, 4294967295ul, 7ul, 2636928640ul, 15ul, 4022730752ul, 18ul, 1812433253ul>&)");
         assert.isAtLeast(response.functions[0].function.id, 0);
         assert.strictEqual(response.functions[0].function.module, "/tmp/build/inner/Debug/build/inner");
@@ -144,7 +151,7 @@ describe("InnerPerfData", function () {
         assert.strictEqual(response.functions[0].function.totalPercent, 72.11286089238845);
         assert.strictEqual(response.functions[0].function.selfPercent, 21.128608923884514);
 
-        assert.strictEqual(response.functions[1].processId, 248);
+        assert.strictEqual(response.functions[1].processKey, process!.key);
         assert.strictEqual(response.functions[1].function.name, "libm.so.6!0x00007f6062b2d34f");
         assert.isAtLeast(response.functions[1].function.id, 0);
         assert.strictEqual(response.functions[1].function.module, "/usr/lib64/libm.so.6");
@@ -154,7 +161,7 @@ describe("InnerPerfData", function () {
         assert.strictEqual(response.functions[1].function.totalPercent, 21.062992125984252);
         assert.strictEqual(response.functions[1].function.selfPercent, 21.062992125984252);
 
-        assert.strictEqual(response.functions[2].processId, 248);
+        assert.strictEqual(response.functions[2].processKey, process!.key);
         assert.strictEqual(response.functions[2].function.name, "std::mersenne_twister_engine<unsigned long, 32ul, 624ul, 397ul, 31ul, 2567483615ul, 11ul, 4294967295ul, 7ul, 2636928640ul, 15ul, 4022730752ul, 18ul, 1812433253ul>::_M_gen_rand()");
         assert.isAtLeast(response.functions[2].function.id, 0);
         assert.strictEqual(response.functions[2].function.module, "/tmp/build/inner/Debug/build/inner");
@@ -167,9 +174,15 @@ describe("InnerPerfData", function () {
 
 
     it("callTreeHotPath", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
             documentId: documentId,
-            processId: 248
+            processKey: process!.key
         });
 
         const root_id = 4294967295; // uint32 max
@@ -246,9 +259,15 @@ describe("InnerPerfData", function () {
     });
 
     it("functionPage", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
+
         const response = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             pageSize: 3,
             pageIndex: 0
         });
@@ -284,13 +303,18 @@ describe("InnerPerfData", function () {
     });
 
     it("expandCallTreeNode", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
 
-        const hot_path = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
+        const hotPathResponse = await fixture.connection.sendRequest(snail.retrieveCallTreeHotPathRequestType, {
             documentId: documentId,
-            processId: 248
+            processKey: process!.key
         });
 
-        var current: snail.CallTreeNode | null = hot_path.root;
+        var current: snail.CallTreeNode | null = hotPathResponse.root;
         while (current && current.children) {
             if (current.name === "main") {
                 break;
@@ -316,7 +340,7 @@ describe("InnerPerfData", function () {
 
         const response = await fixture.connection.sendRequest(snail.expandCallTreeNodeRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             nodeId: current?.id
         });
 
@@ -336,10 +360,15 @@ describe("InnerPerfData", function () {
     });
 
     it("callersCalleesMain", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             pageSize: 200,
             pageIndex: 0
         });
@@ -349,7 +378,7 @@ describe("InnerPerfData", function () {
 
         const response = await fixture.connection.sendRequest(snail.retrieveCallersCalleesRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             functionId: func!.id,
             maxEntries: 2
         });
@@ -364,10 +393,15 @@ describe("InnerPerfData", function () {
     });
 
     it("callersCalleesUniformRealDist", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             pageSize: 200,
             pageIndex: 0
         });
@@ -377,7 +411,7 @@ describe("InnerPerfData", function () {
 
         const response = await fixture.connection.sendRequest(snail.retrieveCallersCalleesRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             functionId: func!.id,
             maxEntries: 1
         });
@@ -390,10 +424,15 @@ describe("InnerPerfData", function () {
     });
 
     it("lineInfoMain", async () => {
+        const processesResponse = await fixture.connection.sendRequest(snail.retrieveProcessesRequestType, {
+            documentId: documentId
+        });
+        const process = processesResponse.processes.find(proc => proc.osId == 248);
+        assert.isDefined(process);
 
         const functionsPage = await fixture.connection.sendRequest(snail.retrieveFunctionsPageRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             pageSize: 200,
             pageIndex: 0
         });
@@ -403,7 +442,7 @@ describe("InnerPerfData", function () {
 
         const response = await fixture.connection.sendRequest(snail.retrieveLineInfoRequestType, {
             documentId: documentId,
-            processId: 248,
+            processKey: process!.key,
             functionId: func!.id,
         });
 

--- a/tests/unit/analysis/module_map.cpp
+++ b/tests/unit/analysis/module_map.cpp
@@ -26,7 +26,7 @@ TEST(ModuleMap, InsertNonOverlapping)
     const module_info<id_data> module_3{.base = 90, .size = 40, .payload = {.id = 3}};
 
     {
-        module_map<id_data> map;
+        module_map<id_data, unsigned int> map;
 
         EXPECT_EQ(map.find(20, 0).first, nullptr);
 
@@ -69,7 +69,7 @@ TEST(ModuleMap, InsertNonOverlapping)
         EXPECT_EQ(map.find(150, 20).first, nullptr);
     }
     {
-        module_map<id_data> map;
+        module_map<id_data, unsigned int> map;
 
         EXPECT_EQ(map.find(20, 0).first, nullptr);
 
@@ -95,7 +95,7 @@ TEST(ModuleMap, InsertNonOverlapping)
         EXPECT_EQ(map.find(150, 20).first, nullptr);
     }
     {
-        module_map<id_data> map;
+        module_map<id_data, unsigned int> map;
 
         EXPECT_EQ(map.find(20, 0).first, nullptr);
 
@@ -135,7 +135,7 @@ TEST(ModuleMap, InsertOverlapping)
     const module_info<id_data> module_4{.base = 40, .size = 50, .payload = {.id = 4}};
 
     {
-        module_map<id_data> map;
+        module_map<id_data, unsigned int> map;
 
         map.insert(module_1, 5);
         map.insert(module_2, 10);
@@ -159,7 +159,7 @@ TEST(ModuleMap, InsertOverlappingExtend)
     const module_info<id_data> module_4{.base = 40, .size = 50, .payload = {.id = 4}};
 
     {
-        module_map<id_data> map;
+        module_map<id_data, unsigned int> map;
 
         map.insert(module_1, 5);
         map.insert(module_2, 10);

--- a/tests/unit/analysis/perf_data_file_process_context.cpp
+++ b/tests/unit/analysis/perf_data_file_process_context.cpp
@@ -219,10 +219,10 @@ TEST(PerfDataFileProcessContext, Processes)
 
     // And another one for proc-a...
     push_fork_event(context.observer(), writable_bytes_buffer,
-                    25, 456, 222);
+                    25, 123, 222);
     // Which gets a name...
     push_comm_event(context.observer(), writable_bytes_buffer,
-                    25, 456, 222, "thread-222");
+                    25, 123, 222, "thread-222");
 
     context.finish();
 
@@ -231,69 +231,76 @@ TEST(PerfDataFileProcessContext, Processes)
 
     const auto& processes_123 = processes.at(123);
     EXPECT_EQ(processes_123.size(), 2);
-    EXPECT_EQ(processes_123[0].id, 123);
-    EXPECT_EQ(processes_123[0].timestamp, 0);
-    EXPECT_EQ(processes_123[0].payload.name, "perf-exec");
-    // EXPECT_EQ(processes_123[0].payload.end_time, 10);
-    EXPECT_EQ(processes_123[1].id, 123);
-    EXPECT_EQ(processes_123[1].timestamp, 10);
-    EXPECT_EQ(processes_123[1].payload.name, "proc-a");
-    EXPECT_EQ(processes_123[1].payload.end_time, std::nullopt);
-
     const auto& processes_456 = processes.at(456);
     EXPECT_EQ(processes_456.size(), 1);
-    EXPECT_EQ(processes_456[0].id, 456);
-    EXPECT_EQ(processes_456[0].timestamp, 15);
-    EXPECT_EQ(processes_456[0].payload.name, "proc-b");
-    EXPECT_EQ(processes_456[0].payload.end_time, std::nullopt);
+
+    const auto& process_123_0 = processes_123.at(0);
+    EXPECT_EQ(process_123_0.id, 123);
+    EXPECT_EQ(process_123_0.timestamp, 0);
+    EXPECT_EQ(process_123_0.payload.name, "perf-exec");
+    EXPECT_EQ(process_123_0.payload.end_time, 10);
+
+    const auto& process_123_1 = processes_123.at(1);
+    EXPECT_EQ(process_123_1.id, 123);
+    EXPECT_EQ(process_123_1.timestamp, 10);
+    EXPECT_EQ(process_123_1.payload.name, "proc-a");
+    EXPECT_EQ(process_123_1.payload.end_time, std::nullopt);
+
+    const auto& process_456_0 = processes_456.at(0);
+    EXPECT_EQ(process_456_0.id, 456);
+    EXPECT_EQ(process_456_0.timestamp, 15);
+    EXPECT_EQ(process_456_0.payload.name, "proc-b");
+    EXPECT_EQ(process_456_0.payload.end_time, std::nullopt);
 
     const auto& threads = context.get_threads().all_entries();
     EXPECT_EQ(threads.size(), 4);
 
     const auto& threads_123 = threads.at(123);
     EXPECT_EQ(threads_123.size(), 2);
-    EXPECT_EQ(threads_123[0].id, 123);
-    EXPECT_EQ(threads_123[0].timestamp, 0);
-    EXPECT_EQ(threads_123[0].payload.name, "perf-exec");
-    // EXPECT_EQ(threads_123[0].payload.end_time, 10);
-    EXPECT_EQ(threads_123[1].id, 123);
-    EXPECT_EQ(threads_123[1].timestamp, 10);
-    EXPECT_EQ(threads_123[1].payload.name, "proc-a");
-    EXPECT_EQ(threads_123[1].payload.end_time, std::nullopt);
-
     const auto& threads_456 = threads.at(456);
     EXPECT_EQ(threads_456.size(), 1);
-    EXPECT_EQ(threads_456[0].id, 456);
-    EXPECT_EQ(threads_456[0].timestamp, 15);
-    EXPECT_EQ(threads_456[0].payload.name, "proc-b");
-    EXPECT_EQ(threads_456[0].payload.end_time, std::nullopt);
-
     const auto& threads_111 = threads.at(111);
     EXPECT_EQ(threads_111.size(), 1);
-    EXPECT_EQ(threads_111[0].id, 111);
-    EXPECT_EQ(threads_111[0].timestamp, 20);
-    EXPECT_EQ(threads_111[0].payload.name, std::nullopt);
-    EXPECT_EQ(threads_111[0].payload.end_time, std::nullopt);
-
     const auto& threads_222 = threads.at(222);
     EXPECT_EQ(threads_222.size(), 1);
-    EXPECT_EQ(threads_222[0].id, 222);
-    EXPECT_EQ(threads_222[0].timestamp, 25);
-    EXPECT_EQ(threads_222[0].payload.name, "thread-222");
-    EXPECT_EQ(threads_222[0].payload.end_time, std::nullopt);
 
-    using threads_per_proc_set = std::set<std::pair<perf_data_file_process_context::thread_id_t, perf_data_file_process_context::timestamp_t>>;
+    const auto& thread_123_0 = threads_123[0];
+    EXPECT_EQ(thread_123_0.id, 123);
+    EXPECT_EQ(thread_123_0.timestamp, 0);
+    EXPECT_EQ(thread_123_0.payload.name, "perf-exec");
+    EXPECT_EQ(thread_123_0.payload.end_time, 10);
 
-    EXPECT_EQ(context.get_process_threads(123), (threads_per_proc_set{
-                                                    {123, 0 },
-                                                    {123, 10}
-    }));
+    const auto& thread_123_1 = threads_123[1];
+    EXPECT_EQ(thread_123_1.id, 123);
+    EXPECT_EQ(thread_123_1.timestamp, 10);
+    EXPECT_EQ(thread_123_1.payload.name, "proc-a");
+    EXPECT_EQ(thread_123_1.payload.end_time, std::nullopt);
 
-    EXPECT_EQ(context.get_process_threads(456), (threads_per_proc_set{
-                                                    {456, 15},
-                                                    {111, 20},
-                                                    {222, 25}
-    }));
+    const auto& thread_456_0 = threads_456[0];
+    EXPECT_EQ(thread_456_0.id, 456);
+    EXPECT_EQ(thread_456_0.timestamp, 15);
+    EXPECT_EQ(thread_456_0.payload.name, "proc-b");
+    EXPECT_EQ(thread_456_0.payload.end_time, std::nullopt);
+
+    const auto& thread_111_0 = threads_111[0];
+    EXPECT_EQ(thread_111_0.id, 111);
+    EXPECT_EQ(thread_111_0.timestamp, 20);
+    EXPECT_EQ(thread_111_0.payload.name, std::nullopt);
+    EXPECT_EQ(thread_111_0.payload.end_time, std::nullopt);
+
+    const auto& thread_222_0 = threads_222[0];
+    EXPECT_EQ(thread_222_0.id, 222);
+    EXPECT_EQ(thread_222_0.timestamp, 25);
+    EXPECT_EQ(thread_222_0.payload.name, "thread-222");
+    EXPECT_EQ(thread_222_0.payload.end_time, std::nullopt);
+
+    using threads_set = std::set<analysis::unique_thread_id>;
+
+    EXPECT_EQ(context.get_process_threads(*process_123_0.payload.unique_id), (threads_set{*thread_123_0.payload.unique_id}));
+
+    EXPECT_EQ(context.get_process_threads(*process_123_1.payload.unique_id), (threads_set{*thread_123_1.payload.unique_id, *thread_222_0.payload.unique_id}));
+
+    EXPECT_EQ(context.get_process_threads(*process_456_0.payload.unique_id), (threads_set{*thread_456_0.payload.unique_id, *thread_111_0.payload.unique_id}));
 }
 
 TEST(PerfDataFileProcessContext, Images)
@@ -359,39 +366,34 @@ TEST(PerfDataFileProcessContext, Samples)
 
     context.finish();
 
-    EXPECT_EQ(context.get_samples_per_process().size(), 2);
+    const auto samples_123 = context.thread_samples(123, 20, 20);
+    EXPECT_EQ(samples_123.size(), 1);
 
-    EXPECT_TRUE(context.get_samples_per_process().contains(123));
-    const auto& samples_123 = context.get_samples_per_process().at(123);
-    EXPECT_EQ(samples_123.first_sample_time, 20);
-    EXPECT_EQ(samples_123.last_sample_time, 30);
-    EXPECT_EQ(samples_123.samples.size(), 3);
+    EXPECT_EQ(samples_123[0].thread_id, 123);
+    EXPECT_EQ(samples_123[0].timestamp, 20);
+    EXPECT_EQ(samples_123[0].instruction_pointer, 0xAA11);
+    EXPECT_EQ(samples_123[0].stack_index, 0);
 
-    EXPECT_EQ(samples_123.samples[0].thread_id, 123);
-    EXPECT_EQ(samples_123.samples[0].timestamp, 20);
-    EXPECT_EQ(samples_123.samples[0].instruction_pointer, 0xAA11);
-    EXPECT_EQ(samples_123.samples[0].stack_index, 0);
+    const auto samples_222 = context.thread_samples(222, 25, 30);
+    EXPECT_EQ(samples_222.size(), 2);
 
-    EXPECT_EQ(samples_123.samples[1].thread_id, 222);
-    EXPECT_EQ(samples_123.samples[1].timestamp, 25);
-    EXPECT_EQ(samples_123.samples[1].instruction_pointer, 0xAA22);
-    EXPECT_EQ(samples_123.samples[1].stack_index, 1);
+    EXPECT_EQ(samples_222[0].thread_id, 222);
+    EXPECT_EQ(samples_222[0].timestamp, 25);
+    EXPECT_EQ(samples_222[0].instruction_pointer, 0xAA22);
+    EXPECT_EQ(samples_222[0].stack_index, 1);
 
-    EXPECT_EQ(samples_123.samples[2].thread_id, 222);
-    EXPECT_EQ(samples_123.samples[2].timestamp, 30);
-    EXPECT_EQ(samples_123.samples[2].instruction_pointer, 0xAA33);
-    EXPECT_EQ(samples_123.samples[2].stack_index, 0);
+    EXPECT_EQ(samples_222[1].thread_id, 222);
+    EXPECT_EQ(samples_222[1].timestamp, 30);
+    EXPECT_EQ(samples_222[1].instruction_pointer, 0xAA33);
+    EXPECT_EQ(samples_222[1].stack_index, 0);
 
-    EXPECT_TRUE(context.get_samples_per_process().contains(456));
-    const auto& samples_456 = context.get_samples_per_process().at(456);
-    EXPECT_EQ(samples_456.first_sample_time, 40);
-    EXPECT_EQ(samples_456.last_sample_time, 40);
-    EXPECT_EQ(samples_456.samples.size(), 1);
+    const auto samples_456 = context.thread_samples(456, 40, 40);
+    EXPECT_EQ(samples_456.size(), 1);
 
-    EXPECT_EQ(samples_456.samples[0].thread_id, 456);
-    EXPECT_EQ(samples_456.samples[0].timestamp, 40);
-    EXPECT_EQ(samples_456.samples[0].instruction_pointer, 0xBB11);
-    EXPECT_EQ(samples_456.samples[0].stack_index, 2);
+    EXPECT_EQ(samples_456[0].thread_id, 456);
+    EXPECT_EQ(samples_456[0].timestamp, 40);
+    EXPECT_EQ(samples_456[0].instruction_pointer, 0xBB11);
+    EXPECT_EQ(samples_456[0].stack_index, 2);
 
     EXPECT_EQ(context.stack(0), (std::vector<std::uint64_t>{0xAAA1, 0xAAA2, 0xAAA3}));
     EXPECT_EQ(context.stack(1), (std::vector<std::uint64_t>{0xAAB1, 0xAAB2}));

--- a/tests/unit/analysis/stacks_analysis.cpp
+++ b/tests/unit/analysis/stacks_analysis.cpp
@@ -32,7 +32,7 @@ struct test_sample_data : public sample_data
 class test_samples_provider : public samples_provider
 {
 public:
-    common::generator<const sample_data&> samples(common::process_id_t process_id,
+    common::generator<const sample_data&> samples(unique_process_id    process_id,
                                                   const sample_filter& filter) const override
     {
         if(process_id != expected_process_id_) co_return;
@@ -43,7 +43,7 @@ public:
         }
     }
 
-    common::process_id_t          expected_process_id_;
+    unique_process_id             expected_process_id_;
     std::vector<test_sample_data> samples_;
 };
 
@@ -52,11 +52,7 @@ using caller_map    = std::unordered_map<function_info::id_t, hit_counts>;
 
 TEST(Analysis, SampleStacksFullInfo)
 {
-    const auto process = process_info{
-        .id         = 42,
-        .name       = "process",
-        .start_time = std::chrono::nanoseconds(10),
-        .end_time   = std::chrono::nanoseconds(20)};
+    const auto process_id = unique_process_id{.key = 123};
 
     const std::string function_a_name = "func_a";
     const std::string function_b_name = "func_b";
@@ -69,7 +65,7 @@ TEST(Analysis, SampleStacksFullInfo)
     const std::string file_b_path = "C:/path/to/file/b.h";
 
     test_samples_provider samples_provider;
-    samples_provider.expected_process_id_ = process.id;
+    samples_provider.expected_process_id_ = process_id;
     samples_provider.samples_             = {
         test_sample_data(
             {stack_frame{
@@ -110,7 +106,9 @@ TEST(Analysis, SampleStacksFullInfo)
             )
     };
 
-    const auto analysis_result = analyze_stacks(samples_provider, process);
+    const auto analysis_result = analyze_stacks(samples_provider, process_id);
+
+    EXPECT_EQ(analysis_result.process_id, process_id);
 
     // Check that all functions are present
     EXPECT_EQ(analysis_result.all_functions().size(), 3);
@@ -288,11 +286,7 @@ TEST(Analysis, SampleStacksFullInfo)
 
 TEST(Analysis, SampleStacksMissingFile)
 {
-    const auto process = process_info{
-        .id         = 42,
-        .name       = "process",
-        .start_time = std::chrono::nanoseconds(10),
-        .end_time   = std::chrono::nanoseconds(20)};
+    const auto process_id = unique_process_id{.key = 123};
 
     const std::string function_a_name = "func_a";
     const std::string function_b_name = "func_b";
@@ -304,7 +298,7 @@ TEST(Analysis, SampleStacksMissingFile)
     const std::string file_a_path = "/home/path/to/file/a.cpp";
 
     test_samples_provider samples_provider;
-    samples_provider.expected_process_id_ = process.id;
+    samples_provider.expected_process_id_ = process_id;
     samples_provider.samples_             = {
         test_sample_data(
             {stack_frame{
@@ -336,7 +330,9 @@ TEST(Analysis, SampleStacksMissingFile)
             )
     };
 
-    const auto analysis_result = analyze_stacks(samples_provider, process);
+    const auto analysis_result = analyze_stacks(samples_provider, process_id);
+
+    EXPECT_EQ(analysis_result.process_id, process_id);
 
     // Check that all functions are present
     EXPECT_EQ(analysis_result.all_functions().size(), 4);

--- a/tests/unit/analysis/stacks_analysis.cpp
+++ b/tests/unit/analysis/stacks_analysis.cpp
@@ -32,7 +32,8 @@ struct test_sample_data : public sample_data
 class test_samples_provider : public samples_provider
 {
 public:
-    common::generator<const sample_data&> samples(common::process_id_t process_id) const override
+    common::generator<const sample_data&> samples(common::process_id_t process_id,
+                                                  const sample_filter& filter) const override
     {
         if(process_id != expected_process_id_) co_return;
 

--- a/tests/unit/analysis/stacks_analysis.cpp
+++ b/tests/unit/analysis/stacks_analysis.cpp
@@ -32,8 +32,8 @@ struct test_sample_data : public sample_data
 class test_samples_provider : public samples_provider
 {
 public:
-    common::generator<const sample_data&> samples(unique_process_id    process_id,
-                                                  const sample_filter& filter) const override
+    common::generator<const sample_data&> samples(unique_process_id process_id,
+                                                  const sample_filter& /*filter*/) const override
     {
         if(process_id != expected_process_id_) co_return;
 
@@ -41,6 +41,12 @@ public:
         {
             co_yield sample;
         }
+    }
+    std::size_t count_samples(unique_process_id process_id,
+                              const sample_filter& /*filter*/) const override
+    {
+        if(process_id != expected_process_id_) return 0;
+        return samples_.size();
     }
 
     unique_process_id             expected_process_id_;


### PR DESCRIPTION
Adds support to apply filters to the samples before performing the analysis.

The samples can be filtered dependent on:
  - A time interval
  - Processes
  - Threads

To make sure the process and thread filters are applied correctly, the code has been refactored to assign unique ids (/keys) to each process and thread. These ids uniquely identify each process/thread within a document and basically replace the identification by the OS pid/tid + a timestep.