### PR TITLE
Fix missing escape sequences in jsonrpc error messages

### DIFF
--- a/snail/jsonrpc/jsonrpc_v2_protocol.cpp
+++ b/snail/jsonrpc/jsonrpc_v2_protocol.cpp
@@ -72,10 +72,15 @@ std::string v2_protocol::dump_response(const jsonrpc::response& response)
 
 std::string v2_protocol::dump_error(const rpc_error& error, const nlohmann::json* id)
 {
+    const auto json_error = nlohmann::json{
+        {"code",    error.code()},
+        {"message", error.what()}
+    };
+
     if(id != nullptr)
     {
-        return std::format(R"({{"jsonrpc":"2.0","error":{{"code":{},"message":"{}"}},"id":{}}})", error.code(), error.what(), id->dump());
+        return std::format(R"({{"jsonrpc":"2.0","error":{},"id":{}}})", json_error.dump(), id->dump());
     }
 
-    return std::format(R"({{"jsonrpc":"2.0","error":{{"code":{},"message":"{}"}}}})", error.code(), error.what());
+    return std::format(R"({{"jsonrpc":"2.0","error":{}}})", json_error.dump());
 }

--- a/tests/unit/jsonrpc/protocol.cpp
+++ b/tests/unit/jsonrpc/protocol.cpp
@@ -141,10 +141,17 @@ TEST(JsonRpcV2Protocol, DumpError)
 {
     v2_protocol protocol;
 
+    const auto id = nlohmann::json("my-id"s);
+
     EXPECT_EQ(protocol.dump_error(rpc_error(123, "my error"), nullptr),
               R"({"jsonrpc":"2.0","error":{"code":123,"message":"my error"}})");
 
-    const auto id = nlohmann::json("my-id"s);
     EXPECT_EQ(protocol.dump_error(rpc_error(123, "my error"), &id),
               R"({"jsonrpc":"2.0","error":{"code":123,"message":"my error"},"id":"my-id"})");
+
+    EXPECT_EQ(protocol.dump_error(rpc_error(123, "error messages \"needs\\escaping\""), nullptr),
+              "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":123,\"message\":\"error messages \\\"needs\\\\escaping\\\"\"}}");
+
+    EXPECT_EQ(protocol.dump_error(rpc_error(123, "error messages \"needs\\escaping\""), &id),
+              "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":123,\"message\":\"error messages \\\"needs\\\\escaping\\\"\"},\"id\":\"my-id\"}");
 }


### PR DESCRIPTION
If an error message includes specific characters like double-quotes, these need to be escaped when creating the json string for the RPC string, which was not handled correctly. To fix this, the error messages is stored in a nlohmann::json object and the dump() method takes care of all the correct escaping.