### PR TITLE
Update vcpkg version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
-      VCPKG_GIT_COMMIT_ID: "f6a5d4e8eb7476b8d7fc12a56dff300c1c986131"
+      VCPKG_GIT_COMMIT_ID: "8eb57355a4ffb410a2e94c07b4dca2dffbee8e50"
 
     steps:
       - name: Install gcc-13
@@ -59,7 +59,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
           sudo apt update
-          sudo apt install clang-17 llvm-17-dev
+          sudo apt install clang-17
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
 
@@ -82,7 +82,7 @@ jobs:
         run: |
           cd "C:\"
           if(Test-Path C:\vcpkg) { rm -r -Force "C:\vcpkg" }
-          git clone --depth 1 --branch "2023.06.20" https://github.com/microsoft/vcpkg.git
+          git clone --depth 1 --branch "2023.10.19" https://github.com/microsoft/vcpkg.git
 
       - name: Restore vcpkg-tool (windows)
         if: runner.os == 'Windows'
@@ -137,19 +137,10 @@ jobs:
 
       - name: Build & Test project (default)
         uses: lukka/run-cmake@v10
-        if: runner.os == 'Linux' && matrix.compiler != 'clang'
+        if: runner.os == 'Linux'
         with:
           configurePreset: "ci"
           configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DVCPKG_VERBOSE=ON', '-DVCPKG_INSTALL_OPTIONS=--debug']"
-          buildPreset: "ci"
-          testPreset: "ci"
-
-      - name: Build & Test project (system LLVM)
-        uses: lukka/run-cmake@v10
-        if: runner.os == 'Linux' && matrix.compiler == 'clang'
-        with:
-          configurePreset: "ci"
-          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Release', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm/']"
           buildPreset: "ci"
           testPreset: "ci"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
-      VCPKG_GIT_COMMIT_ID: "f6a5d4e8eb7476b8d7fc12a56dff300c1c986131"
+      VCPKG_GIT_COMMIT_ID: "8eb57355a4ffb410a2e94c07b4dca2dffbee8e50"
 
     steps:
       - name: Install gcc-13
@@ -38,7 +38,7 @@ jobs:
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
           sudo apt update
-          sudo apt install clang-17 llvm-17-dev
+          sudo apt install clang-17
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
 
@@ -60,7 +60,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: "coverage"
-          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Debug', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}', '-DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm/']"
+          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Debug', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}']"
           buildPreset: "coverage"
           testPreset: "coverage"
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
         uses: lukka/run-cmake@v10
         with:
           configurePreset: "coverage"
-          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Debug', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}']"
+          configurePresetAdditionalArgs: "['-DCMAKE_BUILD_TYPE=Debug', '-DCMAKE_CXX_FLAGS=-gdwarf-4', '-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}']"
           buildPreset: "coverage"
           testPreset: "coverage"
 

--- a/.github/workflows/test-data.yml
+++ b/.github/workflows/test-data.yml
@@ -2,8 +2,6 @@ name: Update Test Data
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
 
 jobs:
   job:

--- a/snail/analysis/detail/dwarf_resolver.cpp
+++ b/snail/analysis/detail/dwarf_resolver.cpp
@@ -7,9 +7,17 @@
 #include <optional>
 
 #ifdef SNAIL_HAS_LLVM
+#    include <llvm/Config/llvm-config.h>
+#    if defined(_MSC_VER) && LLVM_VERSION_MAJOR == 17
+#        pragma warning(push)
+#        pragma warning(disable : 4244)
+#    endif
 #    include <llvm/DebugInfo/DWARF/DWARFContext.h>
 #    include <llvm/Demangle/Demangle.h>
 #    include <llvm/Object/ELFObjectFile.h>
+#    if defined(_MSC_VER) && LLVM_VERSION_MAJOR == 17
+#        pragma warning(pop)
+#    endif
 #endif // SNAIL_HAS_LLVM
 
 #include <snail/common/cast.hpp>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,10 @@
             "dependencies": [
                 {
                     "name": "llvm",
-                    "default-features": false
+                    "default-features": false,
+                    "features": [
+                        "enable-rtti"
+                    ]
                 }
             ]
         }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,10 +16,7 @@
             "dependencies": [
                 {
                     "name": "llvm",
-                    "default-features": false,
-                    "features": [
-                        "default-options"
-                    ]
+                    "default-features": false
                 }
             ]
         }


### PR DESCRIPTION
Update vcpkg to 2023.10.19. This includes an update to LLVM 17, which simplifies the clang pipelines, since we can rely on the LLVM version provided by vcpkg on all platforms now.

Additionally, this fixes some issues related to the upgrade of LLVM and newer compilers in general.