### PR TITLE
Support stack caching events in ETL files

### DIFF
--- a/snail/etl/parser/records/kernel/stackwalk.hpp
+++ b/snail/etl/parser/records/kernel/stackwalk.hpp
@@ -16,6 +16,102 @@
 
 namespace snail::etl::parser {
 
+namespace detail {
+
+template<typename EventView>
+struct stack_iterator
+{
+    using iterator_category = std::random_access_iterator_tag;
+    using difference_type   = std::ptrdiff_t;
+    using value_type        = std::uint64_t;
+    using reference         = std::uint64_t;
+    using pointer           = std::uint64_t*;
+
+    reference operator*() const
+    {
+        return event_view->stack_address(index);
+    }
+
+    stack_iterator& operator++()
+    {
+        ++index;
+        return *this;
+    }
+    stack_iterator operator++(int)
+    {
+        auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+    stack_iterator& operator--()
+    {
+        --index;
+        return *this;
+    }
+    stack_iterator operator--(int)
+    {
+        auto tmp = *this;
+        --(*this);
+        return tmp;
+    }
+
+    stack_iterator& operator+=(difference_type n)
+    {
+        index += n;
+        return *this;
+    }
+
+    stack_iterator& operator-=(difference_type n)
+    {
+        index -= n;
+        return *this;
+    }
+
+    friend constexpr stack_iterator operator+(const stack_iterator& i, difference_type n)
+    {
+        return {i.event_view, i.index + n};
+    }
+    friend constexpr stack_iterator operator-(const stack_iterator& i, difference_type n)
+    {
+        return {i.event_view, i.index - n};
+    }
+
+    friend bool operator==(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index == rhs.index;
+    }
+    friend bool operator!=(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index != rhs.index;
+    }
+    friend bool operator<(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index < rhs.index;
+    }
+    friend bool operator>(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index > rhs.index;
+    }
+    friend bool operator<=(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index <= rhs.index;
+    }
+    friend bool operator>=(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return lhs.index >= rhs.index;
+    }
+
+    friend difference_type operator-(const stack_iterator& lhs, const stack_iterator& rhs)
+    {
+        return difference_type(lhs.index) - difference_type(rhs.index);
+    }
+
+    const EventView* event_view;
+    std::size_t      index;
+};
+
+} // namespace detail
+
 // or _STACK_WALK_EVENT_DATA in ntwmi.h
 // `StackWalk_Event:StackWalk` from wmicore.mof in WDK 10.0.22621.0
 struct stackwalk_v2_stack_event_view : private extract_view_dynamic_base
@@ -47,102 +143,70 @@ struct stackwalk_v2_stack_event_view : private extract_view_dynamic_base
 
     inline std::size_t dynamic_size() const { return dynamic_offset(stack_base_offset, stack_size()); }
 
-    struct stack_iterator
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using difference_type   = std::ptrdiff_t;
-        using value_type        = std::uint64_t;
-        using reference         = std::uint64_t;
-        using pointer           = std::uint64_t*;
-
-        reference operator*() const
-        {
-            return event_view->stack_address(index);
-        }
-
-        stack_iterator& operator++()
-        {
-            ++index;
-            return *this;
-        }
-        stack_iterator operator++(int)
-        {
-            auto tmp = *this;
-            ++(*this);
-            return tmp;
-        }
-        stack_iterator& operator--()
-        {
-            --index;
-            return *this;
-        }
-        stack_iterator operator--(int)
-        {
-            auto tmp = *this;
-            --(*this);
-            return tmp;
-        }
-
-        stack_iterator& operator+=(difference_type n)
-        {
-            index += n;
-            return *this;
-        }
-
-        stack_iterator& operator-=(difference_type n)
-        {
-            index -= n;
-            return *this;
-        }
-
-        friend constexpr stack_iterator operator+(const stack_iterator& i, difference_type n)
-        {
-            return {i.event_view, i.index + n};
-        }
-        friend constexpr stack_iterator operator-(const stack_iterator& i, difference_type n)
-        {
-            return {i.event_view, i.index - n};
-        }
-
-        friend bool operator==(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index == rhs.index;
-        }
-        friend bool operator!=(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index != rhs.index;
-        }
-        friend bool operator<(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index < rhs.index;
-        }
-        friend bool operator>(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index > rhs.index;
-        }
-        friend bool operator<=(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index <= rhs.index;
-        }
-        friend bool operator>=(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return lhs.index >= rhs.index;
-        }
-
-        friend difference_type operator-(const stack_iterator& lhs, const stack_iterator& rhs)
-        {
-            return difference_type(lhs.index) - difference_type(rhs.index);
-        }
-
-        const stackwalk_v2_stack_event_view* event_view;
-        std::size_t                          index;
-    };
-
-    inline std::ranges::subrange<stack_iterator> stack() const
+    inline std::ranges::subrange<detail::stack_iterator<stackwalk_v2_stack_event_view>> stack() const
     {
         return {
-            stack_iterator{this, 0           },
-            stack_iterator{this, stack_size()}
+            detail::stack_iterator<stackwalk_v2_stack_event_view>{this, 0           },
+            detail::stack_iterator<stackwalk_v2_stack_event_view>{this, stack_size()}
+        };
+    }
+};
+
+// `StackWalk_Key:StackWalk` from wmicore.mof in WDK 10.0.22621.0
+struct stackwalk_v2_key_event_view : private extract_view_dynamic_base
+{
+    static inline constexpr std::string_view event_name    = "StackWalk-Key";
+    static inline constexpr std::uint16_t    event_version = 2;
+    static inline constexpr auto             event_types   = std::array{
+        event_identifier_group{event_trace_group::stackwalk, 37, "Kernel"},
+        event_identifier_group{event_trace_group::stackwalk, 38, "User"  }
+    };
+
+    using extract_view_dynamic_base::buffer;
+    using extract_view_dynamic_base::extract_view_dynamic_base;
+
+    inline auto event_timestamp() const { return extract<std::uint64_t>(0); }
+    inline auto process_id() const { return extract<std::uint32_t>(8); }
+    inline auto thread_id() const { return extract<std::uint32_t>(12); }
+    inline auto stack_key() const { return extract_pointer(16); }
+
+    inline std::size_t dynamic_size() const { return dynamic_offset(16, 1); }
+};
+
+// or _STACK_WALK_EVENT_DATA in ntwmi.h
+// `StackWalk_TypeGroup1:StackWalk` from wmicore.mof in WDK 10.0.22621.0
+struct stackwalk_v2_type_group1_event_view : private extract_view_dynamic_base
+{
+    static inline constexpr std::string_view event_name    = "StackWalk-TypeGroup1";
+    static inline constexpr std::uint16_t    event_version = 2;
+    static inline constexpr auto             event_types   = std::array{
+        event_identifier_group{event_trace_group::stackwalk, 34, "Create" },
+        event_identifier_group{event_trace_group::stackwalk, 35, "Delete" },
+        event_identifier_group{event_trace_group::stackwalk, 36, "Rundown"}
+    };
+
+    using extract_view_dynamic_base::buffer;
+    using extract_view_dynamic_base::extract_view_dynamic_base;
+
+    inline auto stack_key() const { return extract_pointer(0); }
+
+    inline std::size_t stack_size() const
+    {
+        return (buffer().size() - pointer_size()) / pointer_size();
+    }
+    inline std::uint64_t stack_address(std::size_t index) const
+    {
+        assert(index < stack_size());
+        return extract_pointer(dynamic_offset(0, 1 + index));
+    }
+
+    inline std::size_t dynamic_size() const { return dynamic_offset(0, 1 + stack_size()); }
+
+    inline std::ranges::subrange<detail::stack_iterator<stackwalk_v2_type_group1_event_view>> stack() const
+    {
+        return {
+            detail::stack_iterator<stackwalk_v2_type_group1_event_view>{this, 0           },
+            detail::stack_iterator<stackwalk_v2_type_group1_event_view>{this, stack_size()}
         };
     }
 };

--- a/tests/unit/etl/parser.cpp
+++ b/tests/unit/etl/parser.cpp
@@ -433,6 +433,48 @@ TEST(EtlParser, Kernel_StackwalkV2StackEventView)
     EXPECT_EQ(*iter7, 18446735292148861325ULL);
 }
 
+TEST(EtlParser, Kernel_StackwalkV2KeyEventView)
+{
+    const std::array<std::uint8_t, 24> buffer = {
+        0x08, 0x78, 0x6c, 0xc9, 0x11, 0x00, 0x00, 0x00, 0x1c, 0x1e, 0x00, 0x00, 0x38, 0x17, 0x00, 0x00,
+        0xa0, 0xbd, 0x16, 0x65, 0x0f, 0xba, 0xff, 0xff};
+
+    const auto event = etl::parser::stackwalk_v2_key_event_view(std::as_bytes(std::span(buffer)), 8);
+
+    EXPECT_EQ(event.dynamic_size(), event.buffer().size());
+
+    EXPECT_EQ(event.event_timestamp(), 76393773064);
+    EXPECT_EQ(event.process_id(), 7708);
+    EXPECT_EQ(event.thread_id(), 5944);
+    EXPECT_EQ(event.stack_key(), 0xffff'ba0f'6516'bda0ULL);
+}
+
+TEST(EtlParser, Kernel_StackwalkV2TypeGroup1EventView)
+{
+    const std::array<std::uint8_t, 80> buffer = {
+        0xe0, 0x9b, 0x11, 0x65, 0x0f, 0xba, 0xff, 0xff, 0x41, 0x6d, 0x90, 0x8a, 0xf6, 0x7f, 0x00, 0x00,
+        0xf3, 0x20, 0xd4, 0x87, 0xf6, 0x7f, 0x00, 0x00, 0x6f, 0x1d, 0xd4, 0x87, 0xf6, 0x7f, 0x00, 0x00,
+        0x17, 0x08, 0x3b, 0x8a, 0xf6, 0x7f, 0x00, 0x00, 0xe6, 0x96, 0x8e, 0x89, 0xf6, 0x7f, 0x00, 0x00,
+        0x97, 0x00, 0x19, 0x89, 0xf6, 0x7f, 0x00, 0x00, 0xba, 0x7e, 0x50, 0x8b, 0xf6, 0x7f, 0x00, 0x00,
+        0x7d, 0x25, 0x7a, 0xba, 0xfe, 0x7f, 0x00, 0x00, 0x28, 0xaf, 0x56, 0xbb, 0xfe, 0x7f, 0x00, 0x00};
+
+    const auto event = etl::parser::stackwalk_v2_type_group1_event_view(std::as_bytes(std::span(buffer)), 8);
+
+    EXPECT_EQ(event.dynamic_size(), event.buffer().size());
+
+    EXPECT_EQ(event.stack_key(), 0xffff'ba0f'6511'9be0ULL);
+    EXPECT_EQ(event.stack_size(), 9);
+    EXPECT_EQ(event.stack_address(0), 0x0000'7ff6'8a90'6d41ULL);
+    EXPECT_EQ(event.stack_address(1), 0x0000'7ff6'87d4'20f3ULL);
+    EXPECT_EQ(event.stack_address(2), 0x0000'7ff6'87d4'1d6fULL);
+    EXPECT_EQ(event.stack_address(3), 0x0000'7ff6'8a3b'0817ULL);
+    EXPECT_EQ(event.stack_address(4), 0x0000'7ff6'898e'96e6ULL);
+    EXPECT_EQ(event.stack_address(5), 0x0000'7ff6'8919'0097ULL);
+    EXPECT_EQ(event.stack_address(6), 0x0000'7ff6'8b50'7ebaULL);
+    EXPECT_EQ(event.stack_address(7), 0x0000'7ffe'ba7a'257dULL);
+    EXPECT_EQ(event.stack_address(8), 0x0000'7ffe'bb56'af28ULL);
+}
+
 TEST(EtlParser, Kernel_ImageV2LoadEventView)
 {
     const std::array<std::uint8_t, 124> buffer = {

--- a/tools/etl_file.cpp
+++ b/tools/etl_file.cpp
@@ -712,9 +712,9 @@ int main(int argc, char* argv[])
             });
         register_known_event_names<etl::parser::stackwalk_v2_type_group1_event_view>(observer.known_group_event_names);
         observer.register_event<etl::parser::stackwalk_v2_type_group1_event_view>(
-            [&options, &observer, &stack_count]([[maybe_unused]] const etl::etl_file::header_data&      file_header,
-                                                [[maybe_unused]] const etl::common_trace_header&        header,
-                                                const etl::parser::stackwalk_v2_type_group1_event_view& event)
+            [&options, &observer]([[maybe_unused]] const etl::etl_file::header_data&      file_header,
+                                  [[maybe_unused]] const etl::common_trace_header&        header,
+                                  const etl::parser::stackwalk_v2_type_group1_event_view& event)
             {
                 assert(event.dynamic_size() == event.buffer().size());
 


### PR DESCRIPTION
Adds support for ETL files with cached stacks (e.g. enabled by `-stackcaching` in `xperf`).