### PR TITLE
Support ETL context switches and total PMC counts

### DIFF
--- a/snail/analysis/data/thread.hpp
+++ b/snail/analysis/data/thread.hpp
@@ -19,6 +19,15 @@ struct thread_info
     // Time since session start
     std::chrono::nanoseconds start_time;
     std::chrono::nanoseconds end_time;
+
+    std::optional<std::size_t> context_switches;
+
+    struct counter_info
+    {
+        std::optional<std::string> name;
+        std::size_t                count;
+    };
+    std::vector<counter_info> counters;
 };
 
 } // namespace snail::analysis

--- a/snail/analysis/perf_data_data_provider.cpp
+++ b/snail/analysis/perf_data_data_provider.cpp
@@ -398,13 +398,15 @@ common::generator<analysis::thread_info> perf_data_data_provider::threads_info(u
         if(thread == nullptr) continue;
 
         co_yield analysis::thread_info{
-            .unique_id  = thread_id,
-            .os_id      = thread->id,
-            .name       = thread->payload.name,
-            .start_time = from_relative_timestamps<std::chrono::nanoseconds>(thread->timestamp, session_start_time_),
-            .end_time   = thread->payload.end_time ?
-                              from_relative_timestamps<std::chrono::nanoseconds>(*thread->payload.end_time, session_start_time_) :
-                              process.end_time};
+            .unique_id        = thread_id,
+            .os_id            = thread->id,
+            .name             = thread->payload.name,
+            .start_time       = from_relative_timestamps<std::chrono::nanoseconds>(thread->timestamp, session_start_time_),
+            .end_time         = thread->payload.end_time ?
+                                    from_relative_timestamps<std::chrono::nanoseconds>(*thread->payload.end_time, session_start_time_) :
+                                    process.end_time,
+            .context_switches = {}, // TODO: get correct values
+            .counters         = {}};
     }
 }
 

--- a/snail/etl/parser/records/kernel/thread.hpp
+++ b/snail/etl/parser/records/kernel/thread.hpp
@@ -134,4 +134,41 @@ private:
     mutable std::optional<std::size_t> thread_name_length;
 };
 
+// `CSwitch_V4:Thread_V4` from wmicore.mof in WDK 10.0.22621.0
+struct thread_v4_context_switch_event_view : private extract_view_dynamic_base
+{
+    static inline constexpr std::string_view event_name    = "Thread-ContextSwitch";
+    static inline constexpr std::uint16_t    event_version = 4;
+    static inline constexpr auto             event_types   = std::array{
+        event_identifier_group{event_trace_group::thread, 36, "ContextSwitch"},
+    };
+
+    using extract_view_dynamic_base::buffer;
+    using extract_view_dynamic_base::extract_view_dynamic_base;
+
+    inline auto new_thread_id() const { return extract<std::uint32_t>(dynamic_offset(0, 0)); }
+    inline auto old_thread_id() const { return extract<std::uint32_t>(dynamic_offset(4, 0)); }
+
+    inline auto new_thread_priority() const { return extract<std::int8_t>(dynamic_offset(8, 0)); }
+    inline auto old_thread_priority() const { return extract<std::int8_t>(dynamic_offset(9, 0)); }
+
+    inline auto previous_c_state() const { return extract<std::uint8_t>(dynamic_offset(10, 0)); }
+
+    inline auto spare_byte() const { return extract<std::int8_t>(dynamic_offset(11, 0)); }
+
+    inline auto old_thread_wait_reason() const { return extract<std::int8_t>(dynamic_offset(12, 0)); }
+
+    inline auto thread_flags() const { return extract<std::int8_t>(dynamic_offset(13, 0)); }
+
+    inline auto old_thread_state() const { return extract<std::int8_t>(dynamic_offset(14, 0)); }
+
+    inline auto old_thread_wait_ideal_processor() const { return extract<std::int8_t>(dynamic_offset(15, 0)); }
+
+    inline auto new_thread_wait_time() const { return extract<std::uint32_t>(dynamic_offset(16, 0)); }
+
+    inline auto reserved() const { return extract<std::uint32_t>(dynamic_offset(20, 0)); }
+
+    inline std::size_t dynamic_size() const { return dynamic_offset(24, 0); }
+};
+
 } // namespace snail::etl::parser

--- a/tests/unit/analysis/helpers.hpp
+++ b/tests/unit/analysis/helpers.hpp
@@ -36,6 +36,11 @@ inline void set_at(std::span<std::byte> buffer, std::size_t bytes_offset, std::u
     destination[value.size()] = '\0';
 }
 
+inline void set_at(std::span<std::byte> buffer, std::size_t bytes_offset, const std::u16string& value)
+{
+    set_at(buffer, bytes_offset, std::u16string_view(value));
+}
+
 inline void set_at(std::span<std::byte> buffer, std::size_t bytes_offset, const common::guid& value)
 {
     set_at(buffer, bytes_offset, value.data_1);

--- a/tests/unit/etl/parser.cpp
+++ b/tests/unit/etl/parser.cpp
@@ -606,6 +606,30 @@ TEST(EtlParser, Kernel_ThreadV4TypeGroup1EventView)
     EXPECT_EQ(event.thread_name(), std::u16string(u"Idle Thread"));
 }
 
+TEST(EtlParser, Kernel_ThreadV4ContextSwitchEventView)
+{
+    const std::array<std::uint8_t, 24> buffer = {
+        0xc0, 0x3b, 0x00, 0x00, 0x48, 0x55, 0x00, 0x00, 0x09, 0x08, 0x00, 0x00, 0x1f, 0x00, 0x01, 0x02,
+        0x1f, 0x00, 0x00, 0x00, 0x85, 0x53, 0x00, 0x00};
+
+    const auto event = etl::parser::thread_v4_context_switch_event_view(std::as_bytes(std::span(buffer)), 8);
+
+    EXPECT_EQ(event.dynamic_size(), event.buffer().size());
+
+    EXPECT_EQ(event.new_thread_id(), 15296);
+    EXPECT_EQ(event.old_thread_id(), 21832);
+    EXPECT_EQ(event.new_thread_priority(), 9);
+    EXPECT_EQ(event.old_thread_priority(), 8);
+    EXPECT_EQ(event.previous_c_state(), 0);
+    EXPECT_EQ(event.spare_byte(), 0);
+    EXPECT_EQ(event.old_thread_wait_reason(), 31);
+    EXPECT_EQ(event.thread_flags(), 0);
+    EXPECT_EQ(event.old_thread_state(), 1);
+    EXPECT_EQ(event.old_thread_wait_ideal_processor(), 2);
+    EXPECT_EQ(event.new_thread_wait_time(), 31);
+    EXPECT_EQ(event.reserved(), 21381);
+}
+
 TEST(EtlParser, Kernel_ThreadV2SetNameEventView)
 {
     const std::array<std::uint8_t, 70> buffer = {

--- a/tools/analysis.cpp
+++ b/tools/analysis.cpp
@@ -88,11 +88,54 @@ int main(int argc, char* argv[])
     auto provider = snail::analysis::make_data_provider(args.file_path.extension(), std::move(args.options), std::move(args.module_path_mapper));
     provider->process(args.file_path);
 
+    const auto& session_info = provider->session_info();
+    std::cout << "Session Info:\n";
+    std::cout << "-------------\n";
+    std::cout << "Command Line:    " << session_info.command_line << "\n";
+    std::cout << "Date:            " << session_info.date << "\n";
+    std::cout << "Runtime:         " << session_info.runtime << "\n";
+    std::cout << "Num. Processes:  " << session_info.number_of_processes << "\n";
+    std::cout << "Num. Threads:    " << session_info.number_of_threads << "\n";
+    std::cout << "Num. Samples:    " << session_info.number_of_samples << "\n";
+
+    const auto& system_info = provider->system_info();
+    std::cout << "\n";
+    std::cout << "System Info:\n";
+    std::cout << "------------\n";
+    std::cout << "Hostname:        " << system_info.hostname << "\n";
+    std::cout << "Platform:        " << system_info.platform << "\n";
+    std::cout << "CPU Name:        " << system_info.cpu_name << "\n";
+    std::cout << "Num. Processors: " << system_info.number_of_processors << "\n";
+    std::cout << "Architecture:    " << system_info.architecture << "\n";
+
+    std::cout << "\n";
+    std::cout << "Processes:\n";
+    std::cout << "----------\n";
     for(const auto process_id : provider->sampling_processes())
     {
-        const auto process_info    = provider->process_info(process_id);
-        const auto stacks_analysis = snail::analysis::analyze_stacks(*provider, process_id);
-        std::cout << process_info.name << " (" << process_info.os_id << "):\n";
+        const auto process_info = provider->process_info(process_id);
+        std::cout << process_info.name << " (PID " << process_info.os_id << "):\n";
+        std::cout << "  Threads:\n";
+        for(const auto& thread_info : provider->threads_info(process_id))
+        {
+            if(thread_info.name)
+            {
+                std::cout << "  " << *thread_info.name << " (TID " << thread_info.os_id << "):\n";
+            }
+            else
+            {
+                std::cout << "    TID " << thread_info.os_id << ":\n";
+            }
+            if(thread_info.context_switches)
+            {
+                std::cout << "      Context Switches: " << *thread_info.context_switches << "\n";
+            }
+            for(const auto& info : thread_info.counters)
+            {
+                std::cout << "      " << (info.name ? *info.name : "UNKNOWN") << ": " << info.count << "\n";
+            }
+        }
+        const auto stacks_analysis = snail::analysis::analyze_stacks(*provider, process_id, {});
         std::cout << "  Modules:   " << stacks_analysis.all_modules().size() << "\n";
         std::cout << "  Functions: " << stacks_analysis.all_functions().size() << "\n";
         std::cout << "  Files:     " << stacks_analysis.all_files().size() << "\n";

--- a/tools/snail-profiler.ps1
+++ b/tools/snail-profiler.ps1
@@ -8,7 +8,10 @@ function Start-Profiling {
         [string]$OutputName = 'profile',
 
         [Parameter()]
-        [string[]]$Pmc = @(),
+        [string[]]$PmcProfile = @(),
+
+        [Parameter()]
+        [string[]]$PmcCount = @(),
 
         [Parameter(Position = 0, ValueFromRemainingArguments)]
         [string[]]$Command,
@@ -44,24 +47,27 @@ function Start-Profiling {
     $kernelEvents = @(
         'PROC_THREAD',
         'LOADER',
-        'PROFILE'
+        'PROFILE',
+        'PERF_COUNTER'
     )
 
     $pmcArgs = @()
-    if ($Pmc.Count -gt 0) {
+    if ($PmcProfile.Count -gt 0) {
         $kernelEvents += 'PMC_PROFILE'
         $pmcArgs += '-PmcProfile'
-        $pmcArgs += $Pmc -join ','
-        foreach ($counterName in $Pmc) {
+        $pmcArgs += $PmcProfile -join ','
+        foreach ($counterName in $PmcProfile) {
             $pmcArgs += '-SetProfInt'
             $pmcArgs += $counterName
             $pmcArgs += $counterInterval
         }
-        # $kernelEvents += 'CSWITCH'
-        # $pmcArgs += '-Pmc'
-        # $pmcArgs += $Pmc -join ','
-        # $pmcArgs += 'CSWITCH'
-        # $pmcArgs += 'strict'
+    }
+    if ($PmcCount.Count -gt 0) {
+        $kernelEvents += 'CSWITCH'
+        $pmcArgs += '-Pmc'
+        $pmcArgs += $PmcCount -join ','
+        $pmcArgs += 'CSWITCH'
+        $pmcArgs += 'strict'
     }
 
     $kernelEventsArg = $kernelEvents -join '+'


### PR DESCRIPTION
Supports context switch events in ETL files. This includes extracting optional PMC counter information from those events and computing the accumulated event count per tread.