### PR TITLE
Support more ETL header events

### DIFF
--- a/tests/unit/etl/parser.cpp
+++ b/tests/unit/etl/parser.cpp
@@ -274,6 +274,53 @@ TEST(EtlParser, Kernel_EventTraceV2HeaderEventView)
     EXPECT_EQ(event.file_name(), std::u16string(u"[multiple files]"));
 }
 
+TEST(EtlParser, Kernel_EventTraceV2HeaderPartitionInfoExtensionTypeGroup)
+{
+    // Seems that this event is always only written with all zeros?
+    const std::array<std::uint8_t, 48> buffer = {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+    const auto event = etl::parser::event_trace_v2_header_partition_info_extension_type_group_event_view(std::as_bytes(std::span(buffer)), 8);
+
+    EXPECT_EQ(event.dynamic_size(), event.buffer().size());
+
+    EXPECT_EQ(event.event_version_(), 0);
+    EXPECT_EQ(event.reserved(), 0);
+    EXPECT_EQ(event.partition_type(), 0);
+    EXPECT_EQ(event.qpc_offset_from_root(), 0);
+    EXPECT_EQ(event.partition_id_guid().instantiate(), (common::guid{
+                                                           0x0000'0000, 0x0000, 0x0000, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+    }));
+    EXPECT_EQ(event.parent_id_guid().instantiate(), (common::guid{
+                                                        0x0000'0000, 0x0000, 0x0000, {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+    }));
+}
+
+TEST(EtlParser, Kernel_EventTraceV2HeaderExtensionTypeGroup)
+{
+    const std::array<std::uint8_t, 36> buffer = {
+        0x0f, 0x00, 0x00, 0x00, 0x06, 0x04, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x55, 0x00, 0x00, 0x00};
+
+    const auto event = etl::parser::event_trace_v2_header_extension_type_group_event_view(std::as_bytes(std::span(buffer)), 8);
+
+    EXPECT_EQ(event.dynamic_size(), event.buffer().size());
+
+    EXPECT_EQ(event.group_mask_1(), 0x0000'000f);
+    EXPECT_EQ(event.group_mask_2(), 0x0000'0406);
+    EXPECT_EQ(event.group_mask_3(), 0x0001'0000);
+    EXPECT_EQ(event.group_mask_4(), 0x0000'0000);
+    EXPECT_EQ(event.group_mask_5(), 0x0000'0000);
+    EXPECT_EQ(event.group_mask_6(), 0x0000'0000);
+    EXPECT_EQ(event.group_mask_7(), 0x0000'0000);
+    EXPECT_EQ(event.group_mask_8(), 0x0000'0000);
+
+    EXPECT_EQ(event.kernel_event_version(), 85);
+}
+
 TEST(EtlParser, Kernel_PerfinfoV2SampledProfileEventView)
 {
     const std::array<std::uint8_t, 16> buffer = {

--- a/tools/etl_file.cpp
+++ b/tools/etl_file.cpp
@@ -594,6 +594,52 @@ int main(int argc, char* argv[])
                 if(options.dump_trace_headers) common::detail::dump_buffer(header.buffer, 0, header.buffer.size(), "header");
                 if(options.dump_events) common::detail::dump_buffer(event.buffer(), 0, event.buffer().size(), "event");
             });
+        register_known_event_names<etl::parser::event_trace_v2_header_extension_type_group_event_view>(observer.known_group_event_names);
+        observer.register_event<etl::parser::event_trace_v2_header_extension_type_group_event_view>(
+            [&options, &observer]([[maybe_unused]] const etl::etl_file::header_data&                        file_header,
+                                  [[maybe_unused]] const etl::common_trace_header&                          header,
+                                  const etl::parser::event_trace_v2_header_extension_type_group_event_view& event)
+            {
+                assert(event.dynamic_size() == event.buffer().size());
+
+                if(!options.show_header) return;
+                if(should_ignore(options, observer.current_event_name)) return;
+
+                std::cout << std::format("@{} {:30}: kernel event version {} mask 1 {:#010x} mask 2 {:#010x} mask 3 {:#010x} mask 4 {:#010x} mask 5 {:#010x} mask 6 {:#010x} mask 7 {:#010x} mask 8 {:#010x}\n", header.timestamp, observer.current_event_name, event.kernel_event_version(), event.group_mask_1(), event.group_mask_2(), event.group_mask_3(), event.group_mask_4(), event.group_mask_5(), event.group_mask_6(), event.group_mask_7(), event.group_mask_8());
+
+                if(options.dump_trace_headers) common::detail::dump_buffer(header.buffer, 0, header.buffer.size(), "header");
+                if(options.dump_events) common::detail::dump_buffer(event.buffer(), 0, event.buffer().size(), "event");
+            });
+        register_known_event_names<etl::parser::event_trace_v2_header_partition_info_extension_type_group_event_view>(observer.known_group_event_names);
+        observer.register_event<etl::parser::event_trace_v2_header_partition_info_extension_type_group_event_view>(
+            [&options, &observer]([[maybe_unused]] const etl::etl_file::header_data&                                       file_header,
+                                  [[maybe_unused]] const etl::common_trace_header&                                         header,
+                                  const etl::parser::event_trace_v2_header_partition_info_extension_type_group_event_view& event)
+            {
+                assert(event.dynamic_size() == event.buffer().size());
+
+                if(!options.show_header) return;
+                if(should_ignore(options, observer.current_event_name)) return;
+
+                std::cout << std::format("@{} {:30} event version {}:\n", header.timestamp, observer.current_event_name, event.event_version_());
+                std::cout << std::format("    reserved:             {}\n", event.reserved());
+                std::cout << std::format("    os_version_major:     {}\n", event.partition_type());
+                std::cout << std::format("    qpc_offset_from_root: {}\n", event.qpc_offset_from_root());
+                std::cout << std::format("    partition_type:       {}\n", event.partition_type());
+                if(event.event_version_() == 2)
+                {
+                    std::cout << std::format("    partition_id:         {}\n", utf8::utf16to8(event.partition_id_str()));
+                    std::cout << std::format("    parent_id:            {}\n", utf8::utf16to8(event.parent_id_str()));
+                }
+                else
+                {
+                    std::cout << std::format("    partition_id:         {}\n", event.partition_id_guid().instantiate().to_string(true));
+                    std::cout << std::format("    parent_id:            {}\n", event.parent_id_guid().instantiate().to_string(true));
+                }
+
+                if(options.dump_trace_headers) common::detail::dump_buffer(header.buffer, 0, header.buffer.size(), "header");
+                if(options.dump_events) common::detail::dump_buffer(event.buffer(), 0, event.buffer().size(), "event");
+            });
     }
 
     // Kernel: config


### PR DESCRIPTION
Similar to #68, these events are not really used yet, but having them supported in ETL tool should be beneficial anyways.