### PR TITLE
Enable building with debug symbols in Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,14 +107,14 @@ jobs:
           VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         run: |
           cd '${{ github.workspace }}'
-          cmake --preset ci . -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release "-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}" "-DVCPKG_INSTALL_OPTIONS=--debug"
-          cmake --build --preset ci .
-          ctest --preset ci
+          cmake --preset ci-${{matrix.platform}} . -G Ninja -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release "-DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}" "-DVCPKG_INSTALL_OPTIONS=--debug"
+          cmake --build --preset ci-${{matrix.platform}} .
+          ctest --preset ci-${{matrix.platform}}
 
       - name: Install
         run: |
-          cmake --install ${{ github.workspace }}/build/ci --component server --prefix ${{ github.workspace }}/install/server
-          cmake --install ${{ github.workspace }}/build/ci --component tools --prefix ${{ github.workspace }}/install/tools
+          cmake --install ${{ github.workspace }}/build/ci-${{matrix.platform}} --component server --prefix ${{ github.workspace }}/install/server
+          cmake --install ${{ github.workspace }}/build/ci-${{matrix.platform}} --component tools --prefix ${{ github.workspace }}/install/tools
 
       - name: Create build info
         shell: pwsh
@@ -132,6 +132,7 @@ jobs:
           name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}
           path: |
             ${{ github.workspace }}/install/server/bin/snail-server*
+            !${{ github.workspace }}/install/server/bin/snail-server*.pdb
             ${{ github.workspace }}/install/server/bin/info.txt
 
       - name: Upload tool binaries
@@ -141,4 +142,23 @@ jobs:
           name: snail-tools-${{ matrix.arch }}-${{ matrix.platform }}
           path: |
             ${{ github.workspace }}/install/tools/bin/snail-tool-*
+            !${{ github.workspace }}/install/tools/bin/snail-tool-*.pdb
+            ${{ github.workspace }}/install/tools/bin/info.txt
+
+      - name: Upload server debug symbols
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols
+          path: |
+            ${{ github.workspace }}/install/server/bin/snail-server*.pdb
+            ${{ github.workspace }}/install/server/bin/info.txt
+
+      - name: Upload tool debug symbols
+        uses: actions/upload-artifact@v4
+        if: runner.os == 'Windows'
+        with:
+          name: snail-tools-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols
+          path: |
+            ${{ github.workspace }}/install/tools/bin/snail-tool-*.pdb
             ${{ github.workspace }}/install/tools/bin/info.txt

--- a/.github/workflows/deploy-head.yml
+++ b/.github/workflows/deploy-head.yml
@@ -78,7 +78,7 @@ jobs:
             release-type: application/gzip
 
     steps:
-      - name: Download build artifacts
+      - name: Download build artifacts (server)
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ci.yml
@@ -86,19 +86,51 @@ jobs:
           name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}
           path: bin
 
+      - name: Download build artifacts (tools)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: ci.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: snail-tools-${{ matrix.arch }}-${{ matrix.platform }}
+          path: tools/bin
+
+      - name: Download build artifacts (server, symbols)
+        uses: dawidd6/action-download-artifact@v6
+        if: matrix.platform == 'windows'
+        with:
+          workflow: ci.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: snail-server-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols
+          skip_unpack: true
+
+      - name: Download build artifacts (tools, symbols)
+        uses: dawidd6/action-download-artifact@v6
+        if: matrix.platform == 'windows'
+        with:
+          workflow: ci.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: snail-tools-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols
+          skip_unpack: true
+
       - name: Repack release asset (zip)
         if: matrix.release-ext == 'zip'
         run: |
           mv ${{ github.workspace }}/bin/info.txt ${{ github.workspace }}/info.txt
           zip snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }} bin/* info.txt
+          mv ${{ github.workspace }}/tools/bin/info.txt ${{ github.workspace }}/tools/info.txt
+          cd tools
+          zip snail-tools-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }} bin/* info.txt
 
       - name: Repack release asset (tar.gz)
         if: matrix.release-ext == 'tar.gz'
         run: |
           mv ${{ github.workspace }}/bin/info.txt ${{ github.workspace }}/info.txt
           tar -cvzf snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }} bin info.txt
+          mv ${{ github.workspace }}/tools/bin/info.txt ${{ github.workspace }}/tools/info.txt
+          cd tools
+          tar -cvzf snail-tools-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }} bin info.txt
 
-      - name: Upload release asset
+      - name: Upload release asset (server)
         shell: pwsh
         run: |
           $assetId = curl -L `
@@ -126,6 +158,95 @@ jobs:
           -H "Content-Type: ${{ matrix.release-type }}" `
           --data-binary "@snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}" `
           "https://uploads.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets?name=snail-server-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}"
+
+      - name: Upload release asset (tools)
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "snail-tools-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/snail-server/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: ${{ matrix.release-type }}" `
+          --data-binary "@tools/snail-tools-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}" `
+          "https://uploads.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets?name=snail-tools-${{ matrix.arch }}-${{ matrix.platform }}.${{ matrix.release-ext }}"
+
+      - name: Upload release asset (server, symbols)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "snail-server-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/snail-server/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: ${{ matrix.release-type }}" `
+          --data-binary "@snail-server-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip" `
+          "https://uploads.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets?name=snail-server-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip"
+
+      - name: Upload release asset (tools, symbols)
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $assetId = curl -L `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          https://api.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets | `
+          ConvertFrom-Json | `
+          Where-Object -Property name -Value "snail-tools-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip" -EQ | `
+          Select-Object -Expand id
+
+          if($assetId) {
+            curl -L `
+            -X DELETE `
+            -H "Accept: application/vnd.github+json" `
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"`
+            -H "X-GitHub-Api-Version: 2022-11-28" `
+            https://api.github.com/repos/albertziegenhagel/snail-server/releases/assets/$assetId
+          }
+
+          curl -i -X POST `
+          -H "Accept: application/vnd.github+json" `
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" `
+          -H "X-GitHub-Api-Version: 2022-11-28" `
+          -H "Content-Type: ${{ matrix.release-type }}" `
+          --data-binary "@snail-tools-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip" `
+          "https://uploads.github.com/repos/albertziegenhagel/snail-server/releases/110773624/assets?name=snail-tools-${{ matrix.arch }}-${{ matrix.platform }}-debug-symbols.zip"
 
   publish:
     name: "Puplish"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ option(SNAIL_WITH_LLVM "Required to resolve symbols from PDB and DWARF files." O
 
 option(SNAIL_ENABLE_SYSTEMTESTS "Whether to enable system testing" ON)
 
+option(SNAIL_INSTALL_PDB "Install PDB files with the DLLs" OFF)
+
 # =======
 # Dependencies
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,7 +7,30 @@
     },
     "configurePresets": [
         {
-            "name": "ci",
+            "name": "windows-debug-symbols",
+            "displayName": "Configure with debug symbols on Windows",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": {
+                    "type": "STRING",
+                    "value": "Embedded"
+                },
+                "CMAKE_EXE_LINKER_FLAGS_INIT": {
+                    "type": "STRING",
+                    "value": "/debug"
+                },
+                "SNAIL_INSTALL_PDB": {
+                    "type": "BOOL",
+                    "value": "ON"
+                }
+            }
+        },
+        {
+            "name": "ci-common",
             "displayName": "Configure for CI",
             "binaryDir": "${sourceDir}/build/${presetName}",
             "generator": "Ninja",
@@ -22,6 +45,21 @@
                     "value": "ON"
                 }
             }
+        },
+        {
+            "name": "ci-windows",
+            "inherits": [
+                "ci-common",
+                "windows-debug-symbols"
+            ],
+            "displayName": "Configure for CI on Windows"
+        },
+        {
+            "name": "ci-linux",
+            "inherits": [
+                "ci-common"
+            ],
+            "displayName": "Configure for CI on Linux"
         },
         {
             "name": "coverage",
@@ -47,9 +85,14 @@
     ],
     "buildPresets": [
         {
-            "name": "ci",
-            "configurePreset": "ci",
-            "displayName": "Build for CI"
+            "name": "ci-windows",
+            "configurePreset": "ci-windows",
+            "displayName": "Build for CI on Windows"
+        },
+        {
+            "name": "ci-linux",
+            "configurePreset": "ci-linux",
+            "displayName": "Build for CI on Linux"
         },
         {
             "name": "coverage",
@@ -59,8 +102,15 @@
     ],
     "testPresets": [
         {
-            "name": "ci",
-            "configurePreset": "ci",
+            "name": "ci-windows",
+            "configurePreset": "ci-windows",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "ci-linux",
+            "configurePreset": "ci-linux",
             "output": {
                 "outputOnFailure": true
             }

--- a/snail/server/CMakeLists.txt
+++ b/snail/server/CMakeLists.txt
@@ -30,3 +30,13 @@ install(
     server
   RUNTIME DESTINATION bin
 )
+if(SNAIL_INSTALL_PDB)
+  install(
+    FILES
+      "$<TARGET_PDB_FILE:snailserver>"
+    COMPONENT
+      server
+    DESTINATION "bin"
+    OPTIONAL
+  )
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -21,3 +21,15 @@ install(
     tools
   RUNTIME DESTINATION bin
 )
+if(SNAIL_INSTALL_PDB)
+  install(
+    FILES
+      "$<TARGET_PDB_FILE:snail_tool_etl>"
+      "$<TARGET_PDB_FILE:snail_tool_perf_data>"
+      "$<TARGET_PDB_FILE:snail_tool_analysis>"
+    COMPONENT
+      tools
+    DESTINATION "bin"
+    OPTIONAL
+  )
+endif()


### PR DESCRIPTION
Enables generating PDB files for the server and tools executables in CI (while still using `Release` as build type). The generated PDBs will be uploaded as build artifacts as well as added to the release artifacts of the rolling release. The idea is to make it easier to debug potential crashes with the released binaries.